### PR TITLE
Don't create output dir if empty

### DIFF
--- a/src/Microsoft.Crank.Controller/Program.cs
+++ b/src/Microsoft.Crank.Controller/Program.cs
@@ -698,7 +698,7 @@ namespace Microsoft.Crank.Controller
                     var filename = _outputOption.Value();
                     
                     var directory = Path.GetDirectoryName(filename);
-                    if (!Directory.Exists(directory))
+                    if (!String.IsNullOrEmpty(directory) && !Directory.Exists(directory))
                     {
                         Directory.CreateDirectory(directory);
                     }


### PR DESCRIPTION
/cc @billwert 

Had an issue while doing `--output baseline.json`