### PR TITLE
metric aggregation fails if metadata not emitted

### DIFF
--- a/src/Microsoft.Crank.Controller/Program.cs
+++ b/src/Microsoft.Crank.Controller/Program.cs
@@ -1554,6 +1554,12 @@ namespace Microsoft.Crank.Controller
                 var reducedValues = groups.SelectMany(x => x)
                     .Where(x => x.Key == metadata.Name);
 
+                // some values are not emitted, even if metadata is present, causing aggregation to fail
+                if (reducedValues.Count() == 0)
+                {
+                    continue;
+                }
+
                 object reducedValue = null;
 
                 switch (metadata.Reduce)


### PR DESCRIPTION
   in some scenarios where for example a build was not performed (using binaries)
   there are metadata emitted without corresponding metrics, causing aggregation failures
   when run on multiple machines