### PR TITLE
Fix project file path

### DIFF
--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -2561,7 +2561,7 @@ namespace Microsoft.Crank.Agent
 
         private static string GetAssemblyName(Job job, string benchmarkedApp)
         {
-            var projectFileName = Path.Combine(benchmarkedApp, Path.GetFileName(FormatPathSeparators(job.Source.Project)));
+            var projectFileName = Path.Combine(benchmarkedApp, FormatPathSeparators(job.Source.Project));
 
             if (File.Exists(projectFileName))
             {


### PR DESCRIPTION
For the following configuration, `GetAssemblyName` fails to locate the csproj file:
```
jobs:
  server:
    source:
      repository: https://github.com/MyRepo
      branchOrCommit: my-branch
      project: src/MyFolder/MyProject.csproj
```
According to the logs, it tries to find the csproj file at `.../MyRepo/MyProject.csproj`, fails to do that, and proceeds without extracting the assembly name. This fix resolved the issue for me, so `.../MyRepo/src/MyFolder/MyProject.csproj` is properly located.

Please note very similar code at:
- https://github.com/dotnet/crank/blob/e2b8f3c58f3b2dcecf05cb4fa6d622ba2b88ca8f/src/Microsoft.Crank.Agent/Startup.cs#L2597
- https://github.com/dotnet/crank/blob/e2b8f3c58f3b2dcecf05cb4fa6d622ba2b88ca8f/src/Microsoft.Crank.Agent/Startup.cs#L2641
I'm not certain they should be fixed as well.