### PR TITLE
Add support for running Bombardier job on Mac OS

### DIFF
--- a/src/Microsoft.Crank.Jobs.Bombardier/Program.cs
+++ b/src/Microsoft.Crank.Jobs.Bombardier/Program.cs
@@ -83,8 +83,8 @@ namespace Microsoft.Crank.Jobs.Bombardier
             using (var fileStream = File.Create(bombardierFileName))
             {
                 await downloadStream.CopyToAsync(fileStream);
-                if (Environment.OSVersion.Platform == PlatformID.Unix ||
-                    Environment.OSVersion.Platform == PlatformID.MacOSX)
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+                    RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
                     Process.Start("chmod", "+x " + bombardierFileName);
                 }

--- a/src/Microsoft.Crank.Jobs.Bombardier/Program.cs
+++ b/src/Microsoft.Crank.Jobs.Bombardier/Program.cs
@@ -70,7 +70,8 @@ namespace Microsoft.Crank.Jobs.Bombardier
             using (var fileStream = File.Create(bombardierFileName))
             {
                 await downloadStream.CopyToAsync(fileStream);
-                if (Environment.OSVersion.Platform == PlatformID.Unix)
+                if (Environment.OSVersion.Platform == PlatformID.Unix ||
+                    Environment.OSVersion.Platform == PlatformID.MacOSX)
                 {
                     Process.Start("chmod", "+x " + bombardierFileName);
                 }

--- a/src/Microsoft.Crank.Jobs.Bombardier/Program.cs
+++ b/src/Microsoft.Crank.Jobs.Bombardier/Program.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Crank.Jobs.Bombardier
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
                     RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
-                    Console.WriteLine($"Setting execute permission on exeecutable {bombardierFileName}");
+                    Console.WriteLine($"Setting execute permission on executable {bombardierFileName}");
                     Process.Start("chmod", "+x " + bombardierFileName);
                 }
 

--- a/src/Microsoft.Crank.Jobs.Bombardier/Program.cs
+++ b/src/Microsoft.Crank.Jobs.Bombardier/Program.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Crank.Jobs.Bombardier
         {
             { PlatformID.Win32NT, "https://github.com/codesenberg/bombardier/releases/download/v1.2.4/bombardier-windows-amd64.exe" },
             { PlatformID.Unix, "https://github.com/codesenberg/bombardier/releases/download/v1.2.4/bombardier-linux-amd64" },
+            { PlatformID.MacOSX, "https://github.com/codesenberg/bombardier/releases/download/v1.2.4/bombardier-darwin-amd64" }
         };
 
         static Program()

--- a/src/Microsoft.Crank.Jobs.Bombardier/Program.cs
+++ b/src/Microsoft.Crank.Jobs.Bombardier/Program.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,13 +21,6 @@ namespace Microsoft.Crank.Jobs.Bombardier
     {
         private static readonly HttpClient _httpClient;
         private static readonly HttpClientHandler _httpClientHandler;
-
-        private static Dictionary<PlatformID, string> _bombardierUrls = new Dictionary<PlatformID, string>()
-        {
-            { PlatformID.Win32NT, "https://github.com/codesenberg/bombardier/releases/download/v1.2.4/bombardier-windows-amd64.exe" },
-            { PlatformID.Unix, "https://github.com/codesenberg/bombardier/releases/download/v1.2.4/bombardier-linux-amd64" },
-            { PlatformID.MacOSX, "https://github.com/codesenberg/bombardier/releases/download/v1.2.4/bombardier-darwin-amd64" }
-        };
 
         static Program()
         {
@@ -63,7 +57,25 @@ namespace Microsoft.Crank.Jobs.Bombardier
 
             args = argsList.ToArray();
 
-            var bombardierUrl = _bombardierUrls[Environment.OSVersion.Platform];
+            string bombardierUrl = null;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                bombardierUrl = "https://github.com/codesenberg/bombardier/releases/download/v1.2.4/bombardier-windows-amd64.exe";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                bombardierUrl = "https://github.com/codesenberg/bombardier/releases/download/v1.2.4/bombardier-linux-amd64";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                bombardierUrl = "https://github.com/codesenberg/bombardier/releases/download/v1.2.4/bombardier-darwin-amd64";
+            }
+            else
+            {
+                Console.WriteLine("Unsupported platform");
+                return;
+            }
+
             var bombardierFileName = Path.GetFileName(bombardierUrl);
 
             Console.WriteLine($"Downloading bombardier from {bombardierUrl} to {bombardierFileName}");

--- a/src/Microsoft.Crank.Jobs.Bombardier/Program.cs
+++ b/src/Microsoft.Crank.Jobs.Bombardier/Program.cs
@@ -89,6 +89,12 @@ namespace Microsoft.Crank.Jobs.Bombardier
                     Console.WriteLine($"Setting execute permission on exeecutable {bombardierFileName}");
                     Process.Start("chmod", "+x " + bombardierFileName);
                 }
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    Console.WriteLine($"Allow running bombardier");
+                    Process.Start("spctl", "--add " + bombardierFileName);
+                }
             }
 
             var baseArguments = String.Join(' ', args.ToArray()) + " --print r --format json";

--- a/src/Microsoft.Crank.Jobs.Bombardier/Program.cs
+++ b/src/Microsoft.Crank.Jobs.Bombardier/Program.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Crank.Jobs.Bombardier
             var bombardierUrl = _bombardierUrls[Environment.OSVersion.Platform];
             var bombardierFileName = Path.GetFileName(bombardierUrl);
 
+            Console.WriteLine($"Downloading bombardier from {bombardierUrl} to {bombardierFileName}");
             using (var downloadStream = await _httpClient.GetStreamAsync(bombardierUrl))
             using (var fileStream = File.Create(bombardierFileName))
             {

--- a/src/Microsoft.Crank.Jobs.Bombardier/Program.cs
+++ b/src/Microsoft.Crank.Jobs.Bombardier/Program.cs
@@ -86,6 +86,7 @@ namespace Microsoft.Crank.Jobs.Bombardier
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
                     RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
+                    Console.WriteLine($"Setting execute permission on exeecutable {bombardierFileName}");
                     Process.Start("chmod", "+x " + bombardierFileName);
                 }
             }

--- a/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
+++ b/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
@@ -10,7 +10,7 @@
 jobs:
   bombardier:
     source:
-      repository: https://github.com/dotnet/crank.git
+      repository: https://github.com/rr-wfm/crank.git
       branchOrCommit: master
       project: src/Microsoft.Crank.Jobs.Bombardier/Microsoft.Crank.Jobs.Bombardier.csproj
     isConsoleApp: true

--- a/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
+++ b/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
@@ -10,8 +10,8 @@
 jobs:
   bombardier:
     source:
-      repository: https://github.com/rr-wfm/crank.git
-      branchOrCommit: feature/bombardier-macos
+      repository: https://github.com/dotnet/crank.git
+      branchOrCommit: master
       project: src/Microsoft.Crank.Jobs.Bombardier/Microsoft.Crank.Jobs.Bombardier.csproj
     isConsoleApp: true
     waitForExit: true

--- a/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
+++ b/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
@@ -11,7 +11,7 @@ jobs:
   bombardier:
     source:
       repository: https://github.com/rr-wfm/crank.git
-      branchOrCommit: master
+      branchOrCommit: feature/bombardier-macos
       project: src/Microsoft.Crank.Jobs.Bombardier/Microsoft.Crank.Jobs.Bombardier.csproj
     isConsoleApp: true
     waitForExit: true


### PR DESCRIPTION
After filing issue #81 I did some research to see if I can figure out why it wasn't working. Turns out it was indeed missing support for running this on Mac OS. Since I'm on a Mac I figured I might as well fix it myself.

I've rewritten the OS detection logic a little bit, because it seemed to be using some old API that doesn't accurately report the difference between Mac en Linux, which was needed in this case. Because of the security features in OSX I also had to run an additional command `spctl --add <executable>` to allow the downloaded executable to be run. Interestingly it asks me for permission to run the tool, but in the mean time it just runs it. But I guess that's an OSX issue.