### PR TITLE
Add serverScheme support to bombardier.yml

### DIFF
--- a/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
+++ b/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
@@ -22,4 +22,4 @@ jobs:
       requests: 0
       rate: 0
       transport: fasthttp # | http1 | http2
-    arguments: "-c {{connections}} -w {{warmup}} -d {{duration}} -n {{requests}} --insecure -l {% if rate != 0 %} --rate {{ rate }} {% endif %} {% if transport %} --{{ transport}} {% endif %} {{headers[presetHeaders]}} {{serverUri}}:{{serverPort}}{{path}}"
+    arguments: "-c {{connections}} -w {{warmup}} -d {{duration}} -n {{requests}} --insecure -l {% if rate != 0 %} --rate {{ rate }} {% endif %} {% if transport %} --{{ transport}} {% endif %} {{headers[presetHeaders]}} {% if serverUri == blank or serverUri == empty %} {{serverScheme}}://{{serverAddress}}:{{serverPort}}{{path}} {% else %} {{serverUri}}:{{serverPort}}{{path}} {% endif %}"


### PR DESCRIPTION
This logic is copied verbatim from wrk.yml: 

https://github.com/dotnet/crank/blob/caf293d98ac2b438b6c77dcb54b72c6d9cc67f3e/src/Microsoft.Crank.Jobs.Wrk/wrk.yml#L33

https://github.com/aspnet/Benchmarks/pull/1587 will depend on this.