### PR TITLE
Fixing trace collection when jobs are stopped

### DIFF
--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -1451,8 +1451,6 @@ namespace Microsoft.Crank.Agent
 
         private static async Task StopPerfcollectAsync(Process perfCollectProcess)
         {
-            Log.WriteLine($"Stopping PerfCollect");
-
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 Log.WriteLine($"PerfCollect is only supported on Linux");

--- a/src/Microsoft.Crank.Models/Job.cs
+++ b/src/Microsoft.Crank.Models/Job.cs
@@ -102,6 +102,11 @@ namespace Microsoft.Crank.Models
         public string PerfViewTraceFile { get; set; }
 
         // Other collection options
+
+        /// <summary>
+        /// Whether to collect the startup phase or not.
+        /// If <c>false</c> (default) the collection is triggered when the ready state is detected.
+        /// </summary>
         public bool CollectStartup { get; set; }
         public bool CollectCounters { get; set; }
 

--- a/src/Microsoft.Crank.Models/JobState.cs
+++ b/src/Microsoft.Crank.Models/JobState.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Crank.Models
         Failed,
         Stopping,
         Stopped,
-        TraceCollecting,
+        TraceCollecting, // The driver has requested the trace to be collected
         TraceCollected,
         Deleting,
         Deleted,


### PR DESCRIPTION
Collection was stopped when the application was stopped normally. The driver is expecting the application to stop in 30s and huge traces would put it in timeout.

The bug is that collection should not stop when Stopping is invoked in a normal path. The driver is supposed to call Stopping then TraceCollecting.

