### PR TITLE
Reuse source or builds between benchmarks

### DIFF
--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -529,17 +529,25 @@ namespace Microsoft.Crank.Agent
                                     {
                                         tempDir = Path.Combine(_rootTempDir, job.Source.SourceKey);
 
-                                        if (!Directory.Exists(tempDir))
+                                        try
                                         {
-                                            Log.WriteLine("Creating resuable: " + tempDir);
-                                            Directory.CreateDirectory(tempDir);
-                                        }
-                                        else
-                                        {
-                                            Log.WriteLine("Reusing folder: " + tempDir);
+                                            if (!Directory.Exists(tempDir))
+                                            {
+                                                Log.WriteLine("Creating source folder: " + tempDir);
+                                                Directory.CreateDirectory(tempDir);
+                                            }
+                                            else
+                                            {
+                                                Log.WriteLine("Found source folder: " + tempDir);
 
-                                            // Force the controller to not send the local folder
-                                            job.Source.LocalFolder = null;
+                                                // Force the controller to not send the local folder
+                                                job.Source.LocalFolder = null;
+                                            }
+                                        }
+                                        catch
+                                        {
+                                            Log.WriteLine("[WARNING] Invalid source folder name: " + tempDir);
+                                            tempDir = null;
                                         }
                                     }
 
@@ -4743,6 +4751,8 @@ namespace Microsoft.Crank.Agent
             Log.WriteLine($"Checking requirements...");
 
             // Add a NuGet.config for the self-contained deployments to be able to find the runtime packages on the CI feeds
+            // This is not taken into account however if the source folder contains its own witha <clear /> statement as this one
+            // is defined in the root benchmarks agent folder.
 
             var rootNugetConfig = Path.Combine(_rootTempDir, "NuGet.Config");
 

--- a/src/Microsoft.Crank.Controller/JobConnection.cs
+++ b/src/Microsoft.Crank.Controller/JobConnection.cs
@@ -111,6 +111,9 @@ namespace Microsoft.Crank.Controller
 
             while (true)
             {
+                // Once the job is in Initializing (previous loop) we need to download the full state
+                // since the source properties might have been changed to dismiss source upload.
+                
                 Job = await GetJobAsync();
 
                 #region Ensure the job is valid

--- a/src/Microsoft.Crank.Controller/Program.cs
+++ b/src/Microsoft.Crank.Controller/Program.cs
@@ -1385,6 +1385,7 @@ namespace Microsoft.Crank.Controller
                     // Compute a custom source key
                     source.SourceKey = source.Repository
                         + source.Project
+                        + source.LocalFolder
                         + source.BranchOrCommit
                         + source.DockerImageName
                         + source.DockerFile
@@ -1392,11 +1393,11 @@ namespace Microsoft.Crank.Controller
                         + source.Repository
                         ;
 
-                    using (SHA256 sha256Hash = SHA256.Create())  
+                    using (var sha1 = SHA1.Create())  
                     {  
                         // Assume no collision since it's verified on the server
-                        var bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(job.Value.Source.SourceKey));
-                        source.SourceKey = Convert.ToBase64String(bytes).Substring(0, 8);
+                        var bytes = sha1.ComputeHash(Encoding.UTF8.GetBytes(job.Value.Source.SourceKey));
+                        source.SourceKey = String.Concat(bytes.Select(b => b.ToString("x2"))).Substring(0, 8);
                     }
 
                     if (job.Value.Options.ReuseBuild)

--- a/src/Microsoft.Crank.Controller/README.md
+++ b/src/Microsoft.Crank.Controller/README.md
@@ -101,7 +101,9 @@ Options:
   ## Files
   --[JOB].options.buildFiles <filename>                                    Build files that will be copied before the application is built. Accepts globing patterns and recursive marker (**). Format is 'path[;destination]'. Path can be a URL. e.g., c:\images\mydockerimage.tar, c:\code\Program.cs
   --[JOB].options.outputFiles <filename>                                   Output files that will be copied in the final application folder. Accepts globing patterns and recursive marker (**). Format is 'path[;destination]'. Path can be a URL. e.g., c:\build\Microsoft.AspNetCore.Mvc.dll, c:\files\samples\picture.png;wwwroot\picture.png
-
+  --[JOB].options.reuseSource <true|false>                                  Reuse local or remote sources across benchmarks for the same source.
+  --[JOB].options.reuseBuild <true|false>                                   Reuse build files across benchmarks. Don't use with floating runtime versions.
+  
   ## Telemetry
 
   --[JOB].options.discardResults <true|false>                              Whether to discard all the results from this job, for instance during a warmup job.

--- a/src/Microsoft.Crank.Models/Job.cs
+++ b/src/Microsoft.Crank.Models/Job.cs
@@ -168,8 +168,6 @@ namespace Microsoft.Crank.Models
         [JsonProperty("BuildArchives")]
         private string[] BuildArchivesArgumentSetter { set { BuildArchivesArgument = value; } }
 
-        // V2
-
         public List<string> Endpoints { get; set; } = new List<string>();
 
         public JObject Variables { get; set; }
@@ -216,5 +214,13 @@ namespace Microsoft.Crank.Models
         public bool BenchmarkDotNet { get; set; }
         public bool? CollectCounters { get; set; }
         public List<string> CounterProviders { get; set; } = new List<string>();
+
+        // Don't clone and don't build if already cloned and built. 
+        // Don't use with floating runtime versions.
+        public bool ReuseBuild { get; set; }
+
+        // Don't clone if already cloned.
+        // Can be used with floating versions.
+        public bool ReuseSource { get; set; }
     }
 }

--- a/src/Microsoft.Crank.Models/Source.cs
+++ b/src/Microsoft.Crank.Models/Source.cs
@@ -24,6 +24,18 @@ namespace Microsoft.Crank.Models
         public string DockerFetchPath { get; set; }
         public string LocalFolder { get; set; }
 
+        /// <summary>
+        /// When set by the controller, the server uses it to reuse the same source folder.
+        /// The value should vary when the source does. When the server can't find the source folder, the LocalFolder property is cleared
+        /// such that the controller doesn't send any local source.
+        /// </summary>
+        public string SourceKey { get; set;}
+
+        /// <summary>
+        /// When SourceKey is defined, indicates whether a build should still occur. 
+        /// </summary>
+        public bool NoBuild { get; set; }
+
         public bool IsDocker()
         {
             return !String.IsNullOrEmpty(DockerFile) || !String.IsNullOrEmpty(DockerImageName);


### PR DESCRIPTION
Example: The application's source can be reused, so it's not cloned again. The load's build files can be reused, so it's not built again.

```
crank --config ..\..\samples\hello\hello.benchmarks.yml --scenario hello --profile local --application.options.reuseSource true --load.options.reuseBuild true
```

When a source parameter is changed, like a branch, or a project name, the source will still be cloned as the source key will change too. 
It doesn't detect the latest commit on a branch though. It could be done automatically by adding it to the computed SourceKey We could also add a custom "VaryBy" property to refresh the source for instance every day, or per user, ... 