### PR TITLE
Fix documentation for collecting event counters

### DIFF
--- a/docs/event_counters.md
+++ b/docs/event_counters.md
@@ -13,7 +13,7 @@ Crank is able to record any predefined set of event counters, the same way [dotn
 The following command line will run a benchmark and record the event counters exposed by the `System.Runtime` provider.
 
 ```
-crank --config /crank/samples/hello/hello.benchmarks.yml --scenario hello --profile local --application.counterProviders System.Runtime --chart
+crank --config /crank/samples/hello/hello.benchmarks.yml --scenario hello --profile local --application.options.counterProviders System.Runtime --chart
 ```
 
 ```


### PR DESCRIPTION
I had some issues following the docs for collecting System.Runtime counters. Specifically, using `--application.counterProviders System.Runtime` as recommended resulted in the error `Could not find part of the configuration path: '[application.counterProviders, System.Runtime]'`

After digging around a bit, I noticed this should actually be `application.options.counterProviders`

This PR is just a quick fix for the documentation.