### PR TITLE
[ProcessUtil] Ensure output buffers are flushed before exit

### DIFF
--- a/src/Microsoft.Crank.Agent/ProcessUtil.cs
+++ b/src/Microsoft.Crank.Agent/ProcessUtil.cs
@@ -113,16 +113,16 @@ namespace Microsoft.Crank.Agent
 
             process.Exited += (_, e) =>
             {
+                // Even though the Exited event has been raised, WaitForExit() must still be called to ensure the output buffers
+                // have been flushed before the process is considered completely done.
+                process.WaitForExit();
+
                 if (throwOnError && process.ExitCode != 0)
                 {
                     processLifetimeTask.TrySetException(new InvalidOperationException($"Command {filename} {arguments} returned exit code {process.ExitCode}"));
                 }
                 else
                 {
-                    // Even though the Exited event has been raised, WaitForExit() must still be called to ensure the output buffers have
-                    // been flushed before saving the output in ProcessResult.
-                    process.WaitForExit();
-
                     processLifetimeTask.TrySetResult(new ProcessResult(process.ExitCode, outputBuilder.ToString(), errorBuilder.ToString()));
                 }
             };

--- a/src/Microsoft.Crank.Agent/ProcessUtil.cs
+++ b/src/Microsoft.Crank.Agent/ProcessUtil.cs
@@ -119,6 +119,10 @@ namespace Microsoft.Crank.Agent
                 }
                 else
                 {
+                    // Even though the Exited event has been raised, WaitForExit() must still be called to ensure the output buffers have
+                    // been flushed before saving the output in ProcessResult.
+                    process.WaitForExit();
+
                     processLifetimeTask.TrySetResult(new ProcessResult(process.ExitCode, outputBuilder.ToString(), errorBuilder.ToString()));
                 }
             };


### PR DESCRIPTION
This seems to fix the issue I was seeing where the output of `cmd /c npm list` was truncated.  There might be other ways to fix this, or other locations to call `WaitForExit()`, but I think this is the smallest possible change that fixes the issue.