### PR TITLE
Call Stop on tracing EventPipeSessions

### DIFF
--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -4140,7 +4140,7 @@ namespace Microsoft.Crank.Agent
                 try
                 {
                     Log.WriteLine("Starting event pipe session");
-                    context.EventPipeSession = client.StartEventPipeSession(providerList);
+                    context.EventPipeSession = client.StartEventPipeSession(providerList, requestRundown: false);
                     break;
                 }
                 catch (ServerNotAvailableException)

--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -5004,6 +5004,7 @@ namespace Microsoft.Crank.Agent
                 await Task.Delay(100);
             }
 
+            traceSession.Stop();
             traceSession.Dispose();
 
             Log.WriteLine($"Tracing finalized");


### PR DESCRIPTION
`EventPipeSession.Stop` needs to be called for the tracing session to successfully receive rundown events. 

In addition, counter sessions don't need rundown so we should specify requestRundown to false while starting the counter session to avoid unnecessary cost of emitting rundown.

