### PR TITLE
Add container size metrics

### DIFF
--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -639,19 +639,6 @@ namespace Microsoft.Crank.Agent
                                         });
                                     }
 
-                                    if (!job.Metadata.Any(x => x.Name == "benchmarks/compressed-image-size"))
-                                    {
-                                        job.Metadata.Enqueue(new MeasurementMetadata
-                                        {
-                                            Source = "Host Process",
-                                            Name = "benchmarks/compressed-image-size",
-                                            Aggregate = Operation.Max,
-                                            Reduce = Operation.Max,
-                                            Format = "n0",
-                                            LongDescription = "The size of the compressed docker image (KB)",
-                                            ShortDescription = "Compressed Image Size (KB)"
-                                        });
-                                    }
 
                                     if (!job.Metadata.Any(x => x.Name == "benchmarks/memory/swap"))
                                     {
@@ -1906,34 +1893,7 @@ namespace Microsoft.Crank.Agent
                         }
                     }
 
-                    var dockerSaveArguments = $"save {imageName} -o {imageName}.tar";
-
-                    var saveResults = await ProcessUtil.RunAsync("docker", dockerSaveArguments,
-                        workingDirectory: srcDir,
-                        cancellationToken: cancellationToken,
-                        log: true,
-                        outputDataReceived: text => job.BuildLog.AddLine(text));
-                    
-                    var gZipArguments = $"{imageName}.tar";
-
-                    var gZipResults = await ProcessUtil.RunAsync("gzip", gZipArguments,
-                        workingDirectory: srcDir,
-                        cancellationToken: cancellationToken,
-                        log: true,
-                        outputDataReceived: text => job.BuildLog.AddLine(text));
-                    
-                    var filePath = Path.Combine(srcDir, $"{imageName}.tar.gz");
-                    var compressedSize = new FileInfo(filePath).Length;
-                    if (compressedSize != 0)
-                    {
-                        job.Measurements.Enqueue(new Measurement
-                        {
-                            Name = "benchmarks/compressed-image-size",
-                            Timestamp = DateTime.UtcNow,
-                            Value = compressedSize / 1024
-                        });
-                        File.Delete(filePath);
-                    }
+                  
                 }
                 else
                 {

--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1895,13 +1895,13 @@ namespace Microsoft.Crank.Agent
                     {
                         if (imageSize != 0)
                         {
-                            job.PublishedSize = imageSize;
+                            job.PublishedSize = imageSize / 1024;
 
                             job.Measurements.Enqueue(new Measurement
                             {
                                 Name = "benchmarks/published-size",
                                 Timestamp = DateTime.UtcNow,
-                                Value = imageSize
+                                Value = imageSize / 1024
                             });
                         }
                     }
@@ -1930,7 +1930,7 @@ namespace Microsoft.Crank.Agent
                         {
                             Name = "benchmarks/compressed-image-size",
                             Timestamp = DateTime.UtcNow,
-                            Value = compressedSize
+                            Value = compressedSize / 1024
                         });
                         File.Delete(filePath);
                     }

--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1926,8 +1926,6 @@ namespace Microsoft.Crank.Agent
                     var compressedSize = new FileInfo(filePath).Length;
                     if (compressedSize != 0)
                     {
-                        job.PublishedSize = compressedSize;
-
                         job.Measurements.Enqueue(new Measurement
                         {
                             Name = "benchmarks/compressed-image-size",


### PR DESCRIPTION
This adds both uncompressed and compressed (for wire size) metrics.

New output from application build:
| application                |         |
| -------------------------- | ------- |
| CPU Usage (%)              | 0       |
| Cores usage (%)            | 0       |
| Working Set (MB)           | 16      |
| Build Time (ms)            | 13,581  |
| Start Time (ms)            | 422     |
| Published Size (KB)        | 238,996 |
| Compressed Image Size (KB) | 94,880  |