### PR TITLE
Support hybrid connections

### DIFF
--- a/src/Microsoft.Crank.Agent/CompositeRelayServer.cs
+++ b/src/Microsoft.Crank.Agent/CompositeRelayServer.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Microsoft.Crank.Agent
+{
+    public class CompositeServer : IServer
+    {
+        private readonly IEnumerable<IServer> _servers;
+
+        public CompositeServer(IEnumerable<IServer> servers)
+        {
+            if (servers == null)
+            {
+                throw new ArgumentNullException(nameof(servers));
+            }
+
+            if (servers.Count() < 2)
+            {
+                throw new ArgumentException("Expected at least 2 servers.", nameof(servers));
+            }
+
+            _servers = servers;
+        }
+        public IFeatureCollection Features => _servers.First().Features;
+
+        public void Dispose()
+        {
+            foreach (var server in _servers)
+            {
+                server.Dispose();
+            }
+        }
+
+        public async Task StartAsync<TContext>(IHttpApplication<TContext> application, CancellationToken cancellationToken) where TContext : notnull
+        {
+            foreach (var server in _servers)
+            {
+                await server.StartAsync(application, cancellationToken);
+            }
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            foreach (var server in _servers)
+            {
+                await server.StopAsync(cancellationToken);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Crank.Controller/Program.cs
+++ b/src/Microsoft.Crank.Controller/Program.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Crank.Controller
                 "Connection string or environment variable name of the SQL Server Database to store results in.", CommandOptionType.SingleValue);
             _sqlTableOption = app.Option("--table",
                 "Table name or environment variable name of the SQL table to store results in.", CommandOptionType.SingleValue);
-            _relayConnectionStringOption = app.Option("--relay", "Connection string or environment variable name of the Azure Relay namespace used to access the Crank Agent endpoints. e.g., 'Endpoint=sb://mynamespace.servicebus.windows.net;...;EntityPath=app'", CommandOptionType.SingleValue);
+            _relayConnectionStringOption = app.Option("--relay", "Connection string or environment variable name of the Azure Relay namespace used to access the Crank Agent endpoints. e.g., 'Endpoint=sb://mynamespace.servicebus.windows.net;...', 'MY_AZURE_RELAY_ENV'", CommandOptionType.SingleValue);
             _sessionOption = app.Option("--session", "A logical identifier to group related jobs.", CommandOptionType.SingleValue);
             _descriptionOption = app.Option("--description", "A string describing the job.", CommandOptionType.SingleValue);
             _propertyOption = app.Option("-p|--property", "Some custom key/value that will be added to the results, .e.g. --property arch=arm --property os=linux", CommandOptionType.MultipleValue);
@@ -2632,6 +2632,10 @@ namespace Microsoft.Crank.Controller
                     if (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable(relayConnectionString)))
                     {
                         return Environment.GetEnvironmentVariable(relayConnectionString);
+                    }
+                    else
+                    {
+                        return relayConnectionString;
                     }
                 }
 

--- a/src/Microsoft.Crank.Controller/README.md
+++ b/src/Microsoft.Crank.Controller/README.md
@@ -37,6 +37,7 @@ Options:
   --chart-type [bar (default) | hex]                             Type of chart to render. Values are 'bar' (default) or 'hex'
   --chart-scale [off (default)| auto]                            Scale for chart. Values are 'off' (default) or 'auto'. When scale is off, the min value starts at 0.
   --script [name]                                                Execute a named script available in the configuration files. Can be used multiple times.
+  --relay <connection_string>                                    Connection string or environment variable name of the Azure Relay namespace used to access the Crank Agent endpoints. e.g., 'Endpoint=sb://mynamespace.servicebus.windows.net;...', 'MY_AZURE_RELAY_ENV';
 
   These options are specific to a Job service named [JOB]
 


### PR DESCRIPTION
When `--relay-enable-http` is set, the agent will listen to both the HTTP port and Azure Relay connection for jobs.

Fixes #325