### PR TITLE
[Doc] Fixed the crank command in "Testing local changes"

### DIFF
--- a/docs/local_application.md
+++ b/docs/local_application.md
@@ -61,7 +61,7 @@ public static void Main(string[] args)
 Execute the following command:
 
 ```
-> crank --config /crank/samples/hello/hello.benchmarks.yml --scenario hello --profile local --application.options.displayOutput true
+> crank --config /crank/samples/local/local.benchmarks.yml --scenario hello --profile local --application.options.displayOutput true
 ```
 
 Notice the `--application.options.displayOutput` argument which will stream the output of the application from the agent:


### PR DESCRIPTION
Hi,

I noticed a small mistake while reading the "Benchmarking local applications" documentation.

The change made in the `Main` method of the program is not taken into account with the given command since the YAML benchmark file used is the one which fetches source from a GitHub repo. It should be the YAML file already used throughout the page (i.e. `sample/local/local.benchmarks.yml`).

Regards