### PR TITLE
[Doc/Samples] Rename variables in microbenchmarks YAML samples to avoid conflict

### DIFF
--- a/docs/microbenchmarks.md
+++ b/docs/microbenchmarks.md
@@ -54,9 +54,9 @@ The following example is available at https://github.com/dotnet/crank/blob/main/
       localFolder: .
       project: micro.csproj
     variables:
-      filter: "*"
-      job: short
-    arguments: --job {{job}} --filter {{filter}} --memory
+      filterArg: "*"
+      jobArg: short
+    arguments: --job {{jobArg}} --filter {{filterArg}} --memory
     options:
       benchmarkDotNet: true
 ```
@@ -80,13 +80,13 @@ Custom arguments can be defined at the job level, or at the scenario level. For 
 
 ```yml
 variables:
-  filter: "*"
-  job: short
-arguments: --job {{job}} --filter {{filter}} --memory
+  filterArg: "*"
+  jobArg: short
+arguments: --job {{jobArg}} --filter {{filterArg}} --memory
 ```
 
 By doing this, each scenario can change the value of these variables.
-More information about the available command line arguments can be found [on the BenchmarDotNet website](https://benchmarkdotnet.org/articles/guides/console-args.html)
+More information about the available command line arguments can be found [on the BenchmarkDotNet website](https://benchmarkdotnet.org/articles/guides/console-args.html)
 
 ## Storing results locally
 
@@ -104,7 +104,7 @@ For instance to run the sockets micro-benchmarks, use this command:
 > crank --config /crank/samples/micro/dotnet.benchmarks.yml --scenario Sockets --profile local
 ```
 
-The file points directly to the GitHub repository, and defines a `filter` argument that will only use the expected classes. You can follow this example to target other benchmarks from this repository.
+The file points directly to the GitHub repository, and defines a `filterArg` argument that will only use the expected classes. You can follow this example to target other benchmarks from this repository.
 
 ## Conclusion
 

--- a/samples/micro/dotnet.benchmarks.yml
+++ b/samples/micro/dotnet.benchmarks.yml
@@ -2,12 +2,12 @@ jobs:
   dotnet:
     source:
       repository: https://github.com/dotnet/performance
-      branchOrCommit: master
+      branchOrCommit: main
       project: src/benchmarks/micro/MicroBenchmarks.csproj
     variables:
-      filter: "*"
-      job: short
-    arguments: --job {{job}} --filter {{filter}} --memory
+      filterArg: "*"
+      jobArg: short
+    arguments: --job {{jobArg}} --filter {{filterArg}} --memory
     framework: netcoreapp3.1
     options:
       benchmarkDotNet: true
@@ -18,13 +18,13 @@ scenarios:
     application:
       job: dotnet
       variables:
-        filter: "*LinqBenchmarks*"
+        filterArg: "*LinqBenchmarks*"
 
   Sockets:
     application:
       job: dotnet
       variables:
-        filter: "*SocketSendReceivePerfTest*"
+        filterArg: "*SocketSendReceivePerfTest*"
 
 profiles:
   local:

--- a/samples/micro/micro.benchmarks.yml
+++ b/samples/micro/micro.benchmarks.yml
@@ -4,9 +4,9 @@ jobs:
       localFolder: .
       project: micro.csproj
     variables:
-      filter: "*"
-      job: short
-    arguments: --job {{job}} --filter {{filter}} --memory
+      filterArg: "*"
+      jobArg: short
+    arguments: --job {{jobArg}} --filter {{filterArg}} --memory
     options:
       benchmarkDotNet: true
     


### PR DESCRIPTION
Hi,

I stumbled upon an issue while reading and testing the "Running micro-benchmarks" section of the documentation.

In the example below (from the `micro.benchmarks.yml` sample), the `job` variable does not expand as expected (we expect `short`) at runtime, and thus results in a error from BenchmarkDotNet (it fails parsing its arguments).

```yaml
  benchmarks:
    source:
      localFolder: .
      project: micro.csproj
    variables:
      filter: "*"
      job: short
    arguments: --job {{job}} --filter {{filter}} --memory
    options:
      benchmarkDotNet: true
```

Here is the output from `crank-agent` (shrinked) : 

```
[11:07:27.276]   Arguments:  --inProcess --cli C:\Users\[...]\src\published\micro.exe --join --exporters briefjson markdown --job {
  "DriverVersion": 0,
  "ServerVersion": 4,
  "Id": 0,

  [...]

  "Dependencies": [],
  "CollectDependencies": false
} --filter * --memory
```

It seems (according to the [`benchmarks.schema.json`](https://github.com/dotnet/crank/blob/main/src/Microsoft.Crank.Controller/benchmarks.schema.json) file) that `job` is already used as a global variable by `crank` to define the job to be executed. That explains why the `job` variable expands to a big JSON block in the output above.

In this PR, I suggest renaming these variables in the `micro.benchmarks.yml` and `dotnet.benchmarks.yml` to `filterArg` and `jobArg` in order to correct this issue and avoid any conflict.

Eventually, I replaced the reference to `master` by `main` in `dotnet.benchmarks.yml` for the `dotnet/performance` repo.

Regards,