### PR TITLE
Improve OS/Architecture checks for Wrk and Wrk2 jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ The benchmarking infrastructure is made of these components:
 - [crank](src/Microsoft.Crank.Controller) - A command line utility that can enqueue jobs and record results
 
 There are also some built in jobs:
-- [wrk](src/Microsoft.Crank.Jobs.Wrk) - An http client benchmarking tool. This tool is used when benchmarking TechEmpower https://github.com/wg/wrk.
-- [wrk2](src/Microsoft.Crank.Jobs.Wrk2) - An http client benchmarking tool optimized for latency testing https://github.com/giltene/wrk2.
-- [bombardier](src/Microsoft.Crank.Jobs.Bombardier) - A go based http client benchmarking tool https://github.com/codesenberg/bombardier.
+- [wrk](src/Microsoft.Crank.Jobs.Wrk) - An http client benchmarking tool. This tool is used when benchmarking TechEmpower https://github.com/wg/wrk (Linux only).
+- [wrk2](src/Microsoft.Crank.Jobs.Wrk2) - An http client benchmarking tool optimized for latency testing https://github.com/giltene/wrk2 (Linux only).
+- [bombardier](src/Microsoft.Crank.Jobs.Bombardier) - A go based http client benchmarking tool https://github.com/codesenberg/bombardier (cross-platform).
 
 ## Get Started
 

--- a/src/Microsoft.Crank.Jobs.Wrk/Program.cs
+++ b/src/Microsoft.Crank.Jobs.Wrk/Program.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Crank.Wrk
     {
         static async Task<int> Main(string[] args)
         {
-            if (Environment.OSVersion.Platform != PlatformID.Unix && RuntimeInformation.ProcessArchitecture != Architecture.X64)
+            if (Environment.OSVersion.Platform != PlatformID.Unix || RuntimeInformation.ProcessArchitecture != Architecture.X64)
             {
                 Console.WriteLine($"Platform not supported: {Environment.OSVersion.Platform}/{RuntimeInformation.ProcessArchitecture}");
                 return -1;

--- a/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
+++ b/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
@@ -31,5 +31,7 @@ jobs:
       serverPath: /
       customHeaders: [ ] # list of headers with the format: '<name1>: <value1>', e.g. [ 'content-type: application/json' ]
     arguments: "-c {{connections}} {% if serverUri == blank or serverUri == empty %} {{serverScheme}}://{{serverAddress}}:{{serverPort}}{{path}} {% else %} {{serverUri}}:{{serverPort}}{{path}} {% endif %} --latency -d {{duration}}s -w {{warmup}}s -t {{threads}} {{headers[presetHeaders]}} {% for h in customHeaders %}{% assign s = h | split : ':' %}--header \"{{ s[0] }}: {{ s[1] | strip }}\" {% endfor %} {% if pipeline > 1 %} -s scripts/pipeline.lua -- {{ pipeline }} {% elsif script != empty or script != blank  %} -s {{script}} -- {{scriptArguments}} {% endif %}"
-    onConfigure: 
+    options:
+      requiredOperatingSystem: linux
+    onConfigure:
       # - job.timeout = Number(job.variables.duration) + Number(job.variables.warmup) + 10;

--- a/src/Microsoft.Crank.Jobs.Wrk2/Program.cs
+++ b/src/Microsoft.Crank.Jobs.Wrk2/Program.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -23,6 +24,12 @@ namespace Microsoft.Crank.Jobs.Wrk2
 
         static async Task<int> Main(string[] args)
         {
+            if (Environment.OSVersion.Platform != PlatformID.Unix || RuntimeInformation.ProcessArchitecture != Architecture.X64)
+            {
+                Console.WriteLine($"Platform not supported: {Environment.OSVersion.Platform}/{RuntimeInformation.ProcessArchitecture}");
+                return -1;
+            }
+
             Console.WriteLine("WRK2 Client");
             Console.WriteLine("args: " + String.Join(' ', args));
 

--- a/src/Microsoft.Crank.Jobs.Wrk2/wrk2.yml
+++ b/src/Microsoft.Crank.Jobs.Wrk2/wrk2.yml
@@ -30,3 +30,5 @@ jobs:
       serverPath: /
       customHeaders: [ ] # list of headers with the format: '<name1>: <value1>', e.g. [ 'content-type: application/json' ]
     arguments: "-c {{connections}} -d {{duration}}s -w {{warmup}}s -t {{threads}} {{headers[presetHeaders]}} {% for h in customHeaders %}{% assign s = h | split : ':' %}--header \"{{ s[0] }}: {{ s[1] | strip }}\" {% endfor %} -R {{rate}} -L {% if serverUri == blank or serverUri == empty %} {{serverScheme}}://{{serverAddress}}:{{serverPort}}{{path}} {% else %} {{serverUri}}:{{serverPort}}{{path}} {% endif %}"
+    options:
+      requiredOperatingSystem: linux


### PR DESCRIPTION
Hi,

This PR improves the OS/Architecture checks made for the Wrk and Wrk2 built-in jobs.

Indeed when I first wanted to try Wrk (and Wrk2) on a Windows Crank Agent, I stumbled upon an error raised by [this line of code](https://github.com/dotnet/crank/blob/main/src/Microsoft.Crank.Jobs.Wrk/WrkProcess.cs#L107) (`chmod` fails on Windows). Checks on the architecture or OS are already made [there](https://github.com/dotnet/crank/blob/main/src/Microsoft.Crank.Jobs.Wrk/Program.cs#L15) but `Windows/x64` does not meet the requirements of the condition and so does not make the program exit as it should. This PR fixes this condition and add it also to the Wrk2 job.

Additionally I saw that the option `requiredOperatingSystem` can be passed to a job in the YAML config file ([as here](https://github.com/dotnet/crank/blob/main/src/Microsoft.Crank.Jobs.H2Load/h2load.yml#L32)), so I added it too to the Wrk and Wrk2 config files. Do you think it's too much? Should we keep only one of the solutions (YAML option or condition in the code)?

Finally I added information about the supported platforms for the built-in jobs provided by this project in the README as I find it a valuable information.

Best regards 😄 