### PR TITLE
Remove unsupported wrk2 argument

### DIFF
--- a/src/Microsoft.Crank.Jobs.Wrk2/Program.cs
+++ b/src/Microsoft.Crank.Jobs.Wrk2/Program.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Crank.Jobs.Wrk2
 
             args = argsList.Select(Quote).ToArray();
 
-            var baseArguments = String.Join(' ', args) + "--format json";
+            var baseArguments = String.Join(' ', args);
 
             var process = new Process()
             {


### PR DESCRIPTION
This change removes the `--print` argument from wrk2 invocations. This argument is not recognized by wrk2, and was causing failures when launching wrk2.
