### PR TITLE
Add support for agent mappings

### DIFF
--- a/src/Microsoft.Crank.Controller/Configuration.cs
+++ b/src/Microsoft.Crank.Controller/Configuration.cs
@@ -42,6 +42,9 @@ namespace Microsoft.Crank.Controller
     public class Scenario
     {
         public string Job { get; set; }
+
+        /// The name of the service defined in a profile.
+        public string Agent { get; set; }
     }
 
     public class CounterList

--- a/src/Microsoft.Crank.RegressionBot/Configuration.cs
+++ b/src/Microsoft.Crank.RegressionBot/Configuration.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 
 namespace Microsoft.Crank.RegressionBot
 {


### PR DESCRIPTION
Fixes #342

Here is how profiles and configs can be rewritten. Note that the current syntax still works.

```yml
imports:
  - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml

jobs:
  server:
    source:
      repository: https://github.com/dotnet/crank
      branchOrCommit: main
      project: samples/hello/hello.csproj
    readyStateText: Application started.

scenarios:
  hello:
    application:
      job: server
      agent: main # the agent to deploy the service on (optional)
    load:
      job: bombardier
      variables:
        serverPort: 5000
        path: /

profiles:
  local:
    variables:
      serverAddress: localhost
    agents: # new name for "jobs" (optional change)
      main:
        aliases: 
          - application # matches a service name without specific agent (optional)
        endpoints: 
          - http://localhost:5010
      secondary:
        aliases: 
          - load
        endpoints: 
          - http://localhost:5010

```