### PR TITLE
Adds support for running CrankAgent as a windows service

### DIFF
--- a/src/Microsoft.Crank.Agent/Microsoft.Crank.Agent.csproj
+++ b/src/Microsoft.Crank.Agent/Microsoft.Crank.Agent.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.WindowsServices" Version="5.0.12" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
     <PackageReference Include="Microsoft.Azure.Relay.AspNetCore" Version="1.3.15173" />
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.251802" />

--- a/src/Microsoft.Crank.Agent/README.md
+++ b/src/Microsoft.Crank.Agent/README.md
@@ -23,4 +23,20 @@ Options:
   --no-cleanup           Don't kill processes or delete temp directories.
   --build-path           The path where applications are built.
   --build-timeout        Maximum duration of build task in minutes. Default 10 minutes.
+  --service              Enables Crank.Agent to run as a windows service
 ```
+
+## Running Crank.Agent as a service
+
+At the moment, only windows service is supported.
+
+Deploy the agent as a dotnet tool (or published), and register the windows service with
+
+```
+SC CREATE "CrankAgentService" binpath= "X:\abosulte_path\crank-agent.exe --url http://exposed-URL:5010 --service"
+```
+
+You also should add the `--dotnethome` and `--build-path` parameters, in order to reuse sdk, and have a dedicated workspace for building and compiling.
+
+The windows service must run with an account having rights on all the folders.
+You also need to allow the exposed port on your windows firewall.


### PR DESCRIPTION
We can't run Crank.Agent as a windows service.
This PR adds an opt-in parameter to let Crank.Agent be windows-service compatible.