### PR TITLE
Wait until application is ready to start counters

### DIFF
--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -4485,9 +4485,6 @@ namespace Microsoft.Crank.Agent
                 RunAndTrace();
             }
 
-            // Don't wait for the counters to be ready as it could get stuck and block the agent
-            var _ = StartCountersAsync(job, context);
-
             if ((job.MemoryLimitInBytes > 0 || !String.IsNullOrWhiteSpace(job.CpuSet)) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 var safeProcess = Kernel32.OpenProcess(ACCESS_MASK.MAXIMUM_ALLOWED, false, (uint)process.Id);
@@ -4559,6 +4556,9 @@ namespace Microsoft.Crank.Agent
             {
                 if (MarkAsRunning(hostname, job, stopwatch))
                 {
+                    // Don't wait for the counters to be ready as it could get stuck and block the agent
+                    var _ = StartCountersAsync(job, context);
+
                     if (!job.CollectStartup)
                     {
                         if (job.Collect)

--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -4798,10 +4798,8 @@ namespace Microsoft.Crank.Agent
 
                 try
                 {
-                    context.EventPipeSession.Dispose();
-
                     // It also interrupts the source.Process() blocking operation
-                    //await context.EventPipeSession.StopAsync(default(CancellationToken));
+                    await context.EventPipeSession.StopAsync(default);
 
                     Log.WriteLine($"Event pipe session stopped ({job.Service}:{job.Id})");
                 }
@@ -4812,6 +4810,11 @@ namespace Microsoft.Crank.Agent
                 catch (Exception e)
                 {
                     Log.WriteLine($"Event pipe session failed stopping ({job.Service}:{job.Id}): {e}");
+                }
+                finally
+                {
+                    context.EventPipeSession.Dispose();
+                    context.EventPipeSession = null;
                 }
             });
 


### PR DESCRIPTION
When counters are started too early in can block the app completely on Linux. Example with Platform benchmarks.