### PR TITLE
Adds Crank.Agent log file support - serilog

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -718,3 +718,201 @@ SOFTWARE.
 -------------------------------------------------------------------
 
 -------------------------------------------------------------------
+
+Serilog 2.10.x  - Apache 2.0
+
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-------------------------------------------------------------------
+
+-------------------------------------------------------------------

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -27,5 +27,10 @@
     <FileSignInfo Include="Serilog.AspNetCore.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Serilog.Extensions.Hosting.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Serilog.Extensions.Logging.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Serilog.Formatting.Compact.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Serilog.Settings.Configuration.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Serilog.Sinks.Console.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Serilog.Sinks.Debug.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Serilog.Sinks.File.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -25,5 +25,7 @@
     <FileSignInfo Include="Vanara.PInvoke.Shared.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Serilog.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Serilog.AspNetCore.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Serilog.Extensions.Hosting.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Serilog.Extensions.Logging.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -23,5 +23,7 @@
     <FileSignInfo Include="Vanara.Core.resources.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Vanara.PInvoke.Kernel32.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Vanara.PInvoke.Shared.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Serilog.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Serilog.AspNetCore.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Crank.Agent/Dumper.cs
+++ b/src/Microsoft.Crank.Agent/Dumper.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Crank.Agent
                         break;
                 }
 
-                Log.WriteLine($"Writing {dumpTypeMessage} to {outputFilePath}");
+                Log.Info($"Writing {dumpTypeMessage} to {outputFilePath}");
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
@@ -82,11 +82,11 @@ namespace Microsoft.Crank.Agent
                  ex is NotSupportedException ||
                  ex is DiagnosticsClientException)
             {
-                Log.WriteLine($"{ex.Message}");
+                Log.Error(ex);
                 return 1;
             }
 
-            Log.WriteLine($"Dump complete");
+            Log.Info($"Dump complete");
             return 0;
         }
     }

--- a/src/Microsoft.Crank.Agent/Git.cs
+++ b/src/Microsoft.Crank.Agent/Git.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Crank.Agent
 
         public static async Task<string> CloneAsync(string path, string repository, bool shallow = true, string branch = null, CancellationToken cancellationToken = default)
         {
-            Log.WriteLine($"Cloning {repository} with branch '{branch}'");
+            Log.Info($"Cloning {repository} with branch '{branch}'");
 
             var branchParam = string.IsNullOrEmpty(branch) ? string.Empty : $"-b {branch}";
 

--- a/src/Microsoft.Crank.Agent/Log.cs
+++ b/src/Microsoft.Crank.Agent/Log.cs
@@ -8,30 +8,73 @@ namespace Microsoft.Crank.Agent
 {
     public static class Log
     {
-        public static void WriteLine(string message, bool timestamp = true)
+        public static void Info(string message, bool timestamp = true)
         {
-            var time = DateTime.Now.ToString("hh:mm:ss.fff");
             if (timestamp)
             {
-                Console.WriteLine($"[{time}] {message}");
+                if (Startup.Logger == null)
+                {
+                    Console.WriteLine($"[{DateTime.Now:hh:mm:ss.fff}] {message}");
+                }
+                else
+                {
+                    Startup.Logger.Information(message);
+                }
             }
             else
             {
-                Console.WriteLine($"{message}");
+                if (Startup.Logger == null)
+                {
+                    Console.WriteLine($"{message}");
+                }
+                else
+                {
+                    Startup.Logger.Information(message);
+                }
             }
         }
 
-        public static void Write(string message, bool timestamp = true)
+        public static void Error(Exception e, string message = null)
         {
-            var time = DateTime.Now.ToString("hh:mm:ss.fff");
-            if (timestamp)
+            if (Startup.Logger == null)
             {
-                Console.Write($"[{time}] {message}");
+                if (string.IsNullOrEmpty(message))
+                {
+                    Console.WriteLine($"[{DateTime.Now:hh:mm:ss.fff}] {e.Message}");
+                }
+                else
+                {
+                    Console.WriteLine($"[{DateTime.Now:hh:mm:ss.fff}] {message} {e.Message}");
+                }
             }
             else
             {
-                Console.Write($"{message}");
+                Startup.Logger.Error(e, message);
             }
         }
+        public static void Error(string message)
+        {
+            if (Startup.Logger == null)
+            {
+                Console.WriteLine($"[{DateTime.Now:hh:mm:ss.fff}] {message}");
+            }
+            else
+            {
+                Startup.Logger.Error(message);
+            }
+        }
+
+        public static void Warning(string message)
+        {
+            if (Startup.Logger == null)
+            {
+                Console.WriteLine($"[{DateTime.Now:hh:mm:ss.fff}] {message}");
+            }
+            else
+            {
+                Startup.Logger.Warning(message);
+            }
+        }
+
     }
 }

--- a/src/Microsoft.Crank.Agent/Microsoft.Crank.Agent.csproj
+++ b/src/Microsoft.Crank.Agent/Microsoft.Crank.Agent.csproj
@@ -29,6 +29,11 @@
     <PackageReference Include="NuGet.Versioning" Version="5.5.1" />
     <PackageReference Include="Vanara.PInvoke.Kernel32" Version="3.3.14" />
     
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <!-- Force version for Component Governance compliance -->
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" >
       <AllowExplicitReference>true</AllowExplicitReference>

--- a/src/Microsoft.Crank.Agent/Microsoft.Crank.Agent.csproj
+++ b/src/Microsoft.Crank.Agent/Microsoft.Crank.Agent.csproj
@@ -28,14 +28,12 @@
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="NuGet.Versioning" Version="5.5.1" />
     <PackageReference Include="Vanara.PInvoke.Kernel32" Version="3.3.14" />
-    
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <!-- Force version for Component Governance compliance -->
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" >
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1">
       <AllowExplicitReference>true</AllowExplicitReference>
     </PackageReference>
   </ItemGroup>

--- a/src/Microsoft.Crank.Agent/ProcessUtil.cs
+++ b/src/Microsoft.Crank.Agent/ProcessUtil.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Crank.Agent
 
             if (log)
             {
-                Log.WriteLine($"[{logWorkingDirectory}] {filename} {arguments}");
+                Log.Info($"[{logWorkingDirectory}] {filename} {arguments}");
             }
 
             using var process = new Process()
@@ -85,7 +85,7 @@ namespace Microsoft.Crank.Agent
 
                     if (log)
                     {
-                        Log.WriteLine(e.Data);
+                        Log.Info(e.Data);
                     }
                 }
             };
@@ -105,7 +105,7 @@ namespace Microsoft.Crank.Agent
                         outputDataReceived.Invoke(e.Data);
                     }
 
-                    Log.WriteLine("[STDERR] " + e.Data);
+                    Log.Info("[STDERR] " + e.Data);
                 }
             };
 
@@ -185,7 +185,7 @@ namespace Microsoft.Crank.Agent
                         throw;
                     }
 
-                    Log.WriteLine($"Attempt {attempts} failed: {e.Message}");
+                    Log.Info($"Attempt {attempts} failed: {e.Message}");
                 }
             } while (true);
         }

--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -38,6 +38,10 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuGet.Versioning;
 using Repository;
+using Serilog;
+using Serilog.Events;
+using Serilog.Filters;
+using Serilog.Sinks.SystemConsole.Themes;
 using Vanara.PInvoke;
 using OperatingSystem = Microsoft.Crank.Models.OperatingSystem;
 
@@ -139,8 +143,11 @@ namespace Microsoft.Crank.Agent
             _relayConnectionStringOption,
             _relayPathOption,
             _relayEnableHttpOption,
-            _runAsService
+            _runAsService,
+            _logPath
             ;
+
+        internal static Serilog.Core.Logger Logger { get; private set; }
 
         static Startup()
         {
@@ -210,27 +217,21 @@ namespace Microsoft.Crank.Agent
 
             app.HelpOption("-?|-h|--help");
 
-            var urlOption = app.Option("-u|--url", $"URL for Rest APIs.  Default is '{_defaultUrl}'.",
-                CommandOptionType.SingleValue);
-            var hostnameOption = app.Option("-n|--hostname", $"Hostname for benchmark server.  Default is '{_defaultHostname}'.",
-                CommandOptionType.SingleValue);
-            var dockerHostnameOption = app.Option("-nd|--docker-hostname", $"Hostname for benchmark server when running Docker on a different hostname.",
-                CommandOptionType.SingleValue);
-            var hardwareOption = app.Option("--hardware", "Hardware (Cloud or Physical).",
-                CommandOptionType.SingleValue);
-            var dotnethomeOption = app.Option("--dotnethome", "Folder to reuse for sdk and runtime installs.",
-                CommandOptionType.SingleValue);
+            var urlOption = app.Option("-u|--url", $"URL for Rest APIs.  Default is '{_defaultUrl}'.", CommandOptionType.SingleValue);
+            var hostnameOption = app.Option("-n|--hostname", $"Hostname for benchmark server.  Default is '{_defaultHostname}'.", CommandOptionType.SingleValue);
+            var dockerHostnameOption = app.Option("-nd|--docker-hostname", $"Hostname for benchmark server when running Docker on a different hostname.", CommandOptionType.SingleValue);
+            var hardwareOption = app.Option("--hardware", "Hardware (Cloud or Physical).", CommandOptionType.SingleValue);
+            var dotnethomeOption = app.Option("--dotnethome", "Folder to reuse for sdk and runtime installs.", CommandOptionType.SingleValue);
             _relayConnectionStringOption = app.Option("--relay", "Connection string or environment variable name of the Azure Relay Hybrid Connection to listen to. e.g., Endpoint=sb://mynamespace.servicebus.windows.net;...", CommandOptionType.SingleValue);
             _relayPathOption = app.Option("--relay-path", "The hybrid connection name used to bind this agent. If not set the --relay argument must contain 'EntityPath={name}'", CommandOptionType.SingleValue);
             _relayEnableHttpOption = app.Option("--relay-enable-http", "Activates the HTTP port even if Azure Relay is used.", CommandOptionType.NoValue);
-            var hardwareVersionOption = app.Option("--hardware-version", "Hardware version (e.g, D3V2, Z420, ...).",
-                CommandOptionType.SingleValue);
-            var noCleanupOption = app.Option("--no-cleanup",
-                "Don't kill processes or delete temp directories.", CommandOptionType.NoValue);
+            var hardwareVersionOption = app.Option("--hardware-version", "Hardware version (e.g, D3V2, Z420, ...).", CommandOptionType.SingleValue);
+            var noCleanupOption = app.Option("--no-cleanup", "Don't kill processes or delete temp directories.", CommandOptionType.NoValue);
             var buildPathOption = app.Option("--build-path", "The path where applications are built.", CommandOptionType.SingleValue);
-            var buildTimeoutOption = app.Option("--build-timeout", "Maximum duration of build task in minutes. Default 10 minutes.",
-                CommandOptionType.SingleValue);
+            var buildTimeoutOption = app.Option("--build-timeout", "Maximum duration of build task in minutes. Default 10 minutes.", CommandOptionType.SingleValue);
             _runAsService = app.Option("--service", "If specified, runs crank-agent as a service", CommandOptionType.NoValue);
+            _logPath = app.Option("--log-path", "The path where the logs are written. Directory must exists.", CommandOptionType.SingleValue);
+
             if (_runAsService.HasValue() && OperatingSystem != OperatingSystem.Windows)
             {
                 throw new PlatformNotSupportedException($"--service is only available on Windows");
@@ -238,6 +239,24 @@ namespace Microsoft.Crank.Agent
 
             app.OnExecute(() =>
             {
+                var logConf = new LoggerConfiguration()
+                 .MinimumLevel.Information()
+                 .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
+                 .Enrich.FromLogContext()
+                 .WriteTo.Console(theme: AnsiConsoleTheme.Code);
+
+                if (_logPath.HasValue())
+                {
+                    var logPath = _logPath.Value();
+                    if (!Directory.Exists(logPath))
+                    {
+                        throw new DirectoryNotFoundException($"Invalid --log-path argument, the directory {logPath} must exists");
+                    }
+                    logConf = logConf.WriteTo.File(Path.Combine(logPath,"crank-agent-log.txt"), rollingInterval: RollingInterval.Day);
+                }
+
+                Logger = logConf.CreateLogger();
+
                 if (noCleanupOption.HasValue())
                 {
                     _cleanup = false;
@@ -301,16 +320,13 @@ namespace Microsoft.Crank.Agent
 
         private static async Task<int> Run(string url, string hostname, string dockerHostname)
         {
+            using var logger = Logger;
             var builder = new WebHostBuilder()
                     .UseKestrel()
                     .ConfigureKestrel(o => o.Limits.MaxRequestBodySize = (long)10 * 1024 * 1024 * 1024)
                     .UseStartup<Startup>()
                     .UseUrls(url)
-                    .ConfigureLogging((hostingContext, logging) =>
-                    {
-                        logging.SetMinimumLevel(LogLevel.Error);
-                        logging.AddConsole();
-                    });
+                    .UseSerilog(Logger);
 
             if (_relayConnectionStringOption.HasValue())
             {
@@ -395,7 +411,7 @@ namespace Microsoft.Crank.Agent
                 Directory.CreateDirectory(dotnethome);
             }
 
-            Log.WriteLine($"Using existing dotnet home folder: {dotnethome}");
+            Log.Info($"Using existing dotnet home folder: {dotnethome}");
 
             var sdkLocation = Path.Combine(dotnethome, "sdk");
 
@@ -405,7 +421,7 @@ namespace Microsoft.Crank.Agent
                 {
                     var sdkVersion = new DirectoryInfo(sdkFolder).Name;
                     _installedSdks.Add(sdkVersion);
-                    Log.WriteLine($"Found sdk {sdkVersion}");
+                    Log.Info($"Found sdk {sdkVersion}");
                 }
             }
             
@@ -417,7 +433,7 @@ namespace Microsoft.Crank.Agent
                 {
                     var runtimeVersion = new DirectoryInfo(runtimeFolder).Name;
                     _installedDotnetRuntimes.Add(runtimeVersion);
-                    Log.WriteLine($"Found runtime {runtimeVersion}");
+                    Log.Info($"Found runtime {runtimeVersion}");
                 }
             }
 
@@ -429,7 +445,7 @@ namespace Microsoft.Crank.Agent
                 {
                     var aspnetVersion = new DirectoryInfo(aspnetFolder).Name;
                     _installedAspNetRuntimes.Add(aspnetVersion);
-                    Log.WriteLine($"Found aspnet {aspnetVersion}");
+                    Log.Info($"Found aspnet {aspnetVersion}");
                 }
             }
 
@@ -441,7 +457,7 @@ namespace Microsoft.Crank.Agent
                 {
                     var desktopVersion = new DirectoryInfo(windowsFolder).Name;
                     _installedDesktopRuntimes.Add(desktopVersion);
-                    Log.WriteLine($"Found desktop {desktopVersion}");
+                    Log.Info($"Found desktop {desktopVersion}");
                 }
             }
 
@@ -455,7 +471,7 @@ namespace Microsoft.Crank.Agent
             {
                 CreateTemporaryFolders();
 
-                Log.WriteLine($"Agent ready, waiting for jobs...");
+                Log.Info($"Agent ready, waiting for jobs...");
 
                 while (!cancellationToken.IsCancellationRequested)
                 {
@@ -466,7 +482,7 @@ namespace Microsoft.Crank.Agent
 
                     foreach (var expiredJob in expiredJobs)
                     {
-                        Log.WriteLine($"Removing expired job {expiredJob.Id}");
+                        Log.Info($"Removing expired job {expiredJob.Id}");
                         _jobs.Remove(expiredJob.Id);
                     }
 
@@ -517,7 +533,7 @@ namespace Microsoft.Crank.Agent
                         {
                             if (!group.ContainsKey(job))
                             {
-                                Log.WriteLine($"Adding job '{job.Service}' ({job.Id}) to group");
+                                Log.Info($"Adding job '{job.Service}' ({job.Id}) to group");
                                 group[job] = new JobContext { Job = job };
                             }
                         }
@@ -525,7 +541,7 @@ namespace Microsoft.Crank.Agent
                         // If the running group is all finished, start the next one
                         if (group.Keys.All(x => x.State == JobState.Deleted))
                         {
-                            Log.WriteLine($"All jobs in group are finished");
+                            Log.Info($"All jobs in group are finished");
 
                             runId = null;
                             break;
@@ -540,13 +556,13 @@ namespace Microsoft.Crank.Agent
 
                             var context = group[job];
 
-                            Log.WriteLine($"Processing job '{job.Service}' ({job.Id}) in state {job.State}");
+                            Log.Info($"Processing job '{job.Service}' ({job.Id}) in state {job.State}");
                             var startProcessing = DateTime.UtcNow;
 
                             if (cancellationToken.IsCancellationRequested)
                             {
                                 // Agent is trying to stop, delete current jobs
-                                Log.WriteLine($"[CRIT] Agent is stopping, deleting job '{job.Service}:{job.Id}'");
+                                Log.Info($"[CRIT] Agent is stopping, deleting job '{job.Service}:{job.Id}'");
                                 job.State = JobState.Deleting;
                             }
 
@@ -565,7 +581,7 @@ namespace Microsoft.Crank.Agent
                             {
                                 var now = DateTime.UtcNow;
 
-                                Log.WriteLine($"Acquiring Job '{job.Service}' ({job.Id})");
+                                Log.Info($"Acquiring Job '{job.Service}' ({job.Id})");
 
                                 // Ensure all local assets are available
                                 await EnsureDotnetInstallExistsAsync();
@@ -573,8 +589,8 @@ namespace Microsoft.Crank.Agent
                                 if (now - job.LastDriverCommunicationUtc > DriverTimeout)
                                 {
                                     // The job needs to be deleted
-                                    Log.WriteLine($"Driver didn't communicate for {DriverTimeout}. Halting job '{job.Service}' ({job.Id}).");
-                                    Log.WriteLine($"{job.State} -> Deleting ({job.Service}:{job.Id})");
+                                    Log.Info($"Driver didn't communicate for {DriverTimeout}. Halting job '{job.Service}' ({job.Id}).");
+                                    Log.Info($"{job.State} -> Deleting ({job.Service}:{job.Id})");
                                     job.State = JobState.Deleting;
                                 }
                                 else
@@ -589,12 +605,12 @@ namespace Microsoft.Crank.Agent
                                         {
                                             if (!Directory.Exists(tempDir))
                                             {
-                                                Log.WriteLine("Creating source folder: " + tempDir);
+                                                Log.Info("Creating source folder: " + tempDir);
                                                 Directory.CreateDirectory(tempDir);
                                             }
                                             else
                                             {
-                                                Log.WriteLine("Found source folder: " + tempDir);
+                                                Log.Info("Found source folder: " + tempDir);
 
                                                 // Force the controller to not send the local folder
                                                 job.Source.LocalFolder = null;
@@ -602,7 +618,7 @@ namespace Microsoft.Crank.Agent
                                         }
                                         catch
                                         {
-                                            Log.WriteLine("[WARNING] Invalid source folder name: " + tempDir);
+                                            Log.Warning("[WARNING] Invalid source folder name: " + tempDir);
                                             tempDir = null;
                                         }
                                     }
@@ -613,7 +629,7 @@ namespace Microsoft.Crank.Agent
                                     }
 
                                     startMonitorTime = DateTime.UtcNow;
-                                    Log.WriteLine($"{job.State} -> Initializing ({job.Service}:{job.Id})");
+                                    Log.Info($"{job.State} -> Initializing ({job.Service}:{job.Id})");
                                     job.State = JobState.Initializing;
                                 }
 
@@ -742,8 +758,8 @@ namespace Microsoft.Crank.Agent
                                 // Clean the job in case the driver is not running
                                 if (now - job.LastDriverCommunicationUtc > DriverTimeout)
                                 {
-                                    Log.WriteLine($"Driver didn't communicate for {DriverTimeout}. Halting job.");
-                                    Log.WriteLine($"{job.State} -> Deleting ({job.Service}:{job.Id})");
+                                    Log.Info($"Driver didn't communicate for {DriverTimeout}. Halting job.");
+                                    Log.Info($"{job.State} -> Deleting ({job.Service}:{job.Id})");
                                     job.State = JobState.Deleting;
                                 }
                             }
@@ -757,15 +773,15 @@ namespace Microsoft.Crank.Agent
                                         job.WebHost == WebHost.IISOutOfProcess)
                                         )
                                     {
-                                        Log.WriteLine($"Skipping job '{job.Service}' ({job.Id})");
-                                        Log.WriteLine($"'{job.WebHost}' is not supported on this platform.");
-                                        Log.WriteLine($"{job.State} -> NotSupported");
+                                        Log.Info($"Skipping job '{job.Service}' ({job.Id})");
+                                        Log.Info($"'{job.WebHost}' is not supported on this platform.");
+                                        Log.Info($"{job.State} -> NotSupported");
                                         job.State = JobState.NotSupported;
                                         continue;
                                     }
 
-                                    Log.WriteLine($"Starting job '{job.Service}' ({job.Id})");
-                                    Log.WriteLine($"{job.State} -> Starting ({job.Service}:{job.Id})");
+                                    Log.Info($"Starting job '{job.Service}' ({job.Id})");
+                                    Log.Info($"{job.State} -> Starting ({job.Service}:{job.Id})");
                                     job.State = JobState.Starting;
 
                                     startMonitorTime = DateTime.UtcNow;
@@ -804,7 +820,7 @@ namespace Microsoft.Crank.Agent
                                             {
                                                 process = await StartProcess(hostname, Path.Combine(tempDir, benchmarksDir), job, _dotnethome, context);
 
-                                                Log.WriteLine($"Process started: {job.ProcessId}");
+                                                Log.Info($"Process started: {job.ProcessId}");
 
                                                 workingDirectory = process.StartInfo.WorkingDirectory;
                                             }
@@ -818,9 +834,9 @@ namespace Microsoft.Crank.Agent
                                         // Cancel the build if the driver timed out
                                         if (DateTime.UtcNow - job.LastDriverCommunicationUtc > DriverTimeout)
                                         {
-                                            Log.WriteLine($"Driver didn't communicate for {DriverTimeout}. Halting build.");
+                                            Log.Info($"Driver didn't communicate for {DriverTimeout}. Halting build.");
 
-                                            Log.WriteLine($"{job.State} -> Failed ({job.Service}:{job.Id})");
+                                            Log.Info($"{job.State} -> Failed ({job.Service}:{job.Id})");
                                             job.State = JobState.Failed;
 
                                             cts.Cancel();
@@ -828,17 +844,17 @@ namespace Microsoft.Crank.Agent
 
                                             if (!buildAndRunTask.IsCompleted)
                                             {
-                                                Log.WriteLine($"Build couldn't not be interrupted");
+                                                Log.Info($"Build couldn't not be interrupted");
                                             }
                                         }
 
                                         // Cancel the build if it's taking too long
                                         if (DateTime.UtcNow - buildStart > buildTimeout)
                                         {
-                                            Log.WriteLine($"Build is taking too long. Halting build.");
+                                            Log.Info($"Build is taking too long. Halting build.");
                                             job.Error = "Build is taking too long. Halting build.";
 
-                                            Log.WriteLine($"{job.State} -> Failed ({job.Service}:{job.Id})");
+                                            Log.Info($"{job.State} -> Failed ({job.Service}:{job.Id})");
                                             job.State = JobState.Failed;
 
                                             cts.Cancel();
@@ -847,10 +863,10 @@ namespace Microsoft.Crank.Agent
 
                                         if (buildAndRunTask.IsFaulted)
                                         {
-                                            Log.WriteLine($"An unexpected error occurred while building the job. {buildAndRunTask.Exception}");
+                                            Log.Info($"An unexpected error occurred while building the job. {buildAndRunTask.Exception}");
                                             job.Error = $"An unexpected error occurred while building the job: {buildAndRunTask.Exception.Message}";
 
-                                            Log.WriteLine($"{job.State} -> Failed ({job.Service}:{job.Id})");
+                                            Log.Info($"{job.State} -> Failed ({job.Service}:{job.Id})");
                                             job.State = JobState.Failed;
 
                                             cts.Cancel();
@@ -889,7 +905,7 @@ namespace Microsoft.Crank.Agent
                                             {
                                                 if (context.Disposed || context.Timer == null)
                                                 {
-                                                    Log.WriteLine($"[Warning!!!] Heartbeat still active while context is disposed ({job.Service}:{job.Id})");
+                                                    Log.Info($"[Warning!!!] Heartbeat still active while context is disposed ({job.Service}:{job.Id})");
                                                     return;
                                                 }
 
@@ -905,13 +921,13 @@ namespace Microsoft.Crank.Agent
                                                     {
                                                         if (job.State == JobState.Running)
                                                         {
-                                                            Log.WriteLine($"[Heartbeat] Driver didn't communicate for {DriverTimeout}. Halting job '{job.Service}' ({job.Id}).");
-                                                            Log.WriteLine($"{job.State} -> Stopping ({job.Service}:{job.Id})");
+                                                            Log.Info($"[Heartbeat] Driver didn't communicate for {DriverTimeout}. Halting job '{job.Service}' ({job.Id}).");
+                                                            Log.Info($"{job.State} -> Stopping ({job.Service}:{job.Id})");
                                                             job.State = JobState.Stopping;
                                                         }
                                                         else
                                                         {
-                                                            Log.WriteLine($"Heartbeat is active ({job.Service}:{job.Id}), job is '{job.State}' and driver is AWOL. Job deletion must have failed.");
+                                                            Log.Info($"Heartbeat is active ({job.Service}:{job.Id}), job is '{job.State}' and driver is AWOL. Job deletion must have failed.");
                                                         }
                                                     }
 
@@ -925,8 +941,8 @@ namespace Microsoft.Crank.Agent
 
                                                         if (String.Equals(inspectResult.StandardOutput.Trim(), "false"))
                                                         {
-                                                            Log.WriteLine($"The Docker container has stopped");
-                                                            Log.WriteLine($"{job.State} -> Stopping ({job.Service}:{job.Id})");
+                                                            Log.Info($"The Docker container has stopped");
+                                                            Log.Info($"{job.State} -> Stopping ({job.Service}:{job.Id})");
                                                             job.State = JobState.Stopping;
                                                         }
                                                         else if (job.State == JobState.Running)
@@ -1015,7 +1031,7 @@ namespace Microsoft.Crank.Agent
                                                                         }
                                                                         catch (Exception e)
                                                                         {
-                                                                            Log.WriteLine($"[ERROR] Could not get swap memory:" + e.ToString());
+                                                                            Log.Error(e, $"[ERROR] Could not get swap memory:");
                                                                         }
                                                                     }
                                                                 }
@@ -1030,19 +1046,19 @@ namespace Microsoft.Crank.Agent
 
                                                             if (process.ExitCode != 0)
                                                             {
-                                                                Log.WriteLine($"Job failed");
+                                                                Log.Info($"Job failed");
 
                                                                 job.Error = $"Job failed at runtime with exit code {process.ExitCode}:\n{job.Output}";
 
                                                                 if (job.State != JobState.Deleting)
                                                                 {
-                                                                    Log.WriteLine($"{job.State} -> Failed ({job.Service}:{job.Id})");
+                                                                    Log.Info($"{job.State} -> Failed ({job.Service}:{job.Id})");
                                                                     job.State = JobState.Failed;
                                                                 }
                                                             }
                                                             else
                                                             {
-                                                                Log.WriteLine($"Process has exited with exit code {process.ExitCode} ({job.Service}:{job.Id})");
+                                                                Log.Info($"Process has exited with exit code {process.ExitCode} ({job.Service}:{job.Id})");
 
                                                                 // Don't revert a Deleting state by mistake
                                                                 if (job.State != JobState.Deleting
@@ -1052,7 +1068,7 @@ namespace Microsoft.Crank.Agent
                                                                     && job.State != JobState.Deleted
                                                                     )
                                                                 {
-                                                                    Log.WriteLine($"{job.State} -> Stopped ({job.Service}:{job.Id})");
+                                                                    Log.Info($"{job.State} -> Stopped ({job.Service}:{job.Id})");
                                                                     job.State = JobState.Stopped;
                                                                 }
                                                             }
@@ -1146,7 +1162,7 @@ namespace Microsoft.Crank.Agent
                                                                         }
                                                                         catch (Exception e)
                                                                         {
-                                                                            Log.WriteLine($"[ERROR] Could not get swap memory:" + e.ToString());
+                                                                            Log.Error(e, $"[ERROR] Could not get swap memory:");
                                                                         }
                                                                     }
                                                                 }
@@ -1158,7 +1174,7 @@ namespace Microsoft.Crank.Agent
                                                 }
                                                 catch
                                                 {
-                                                    Log.WriteLine("An error occurred while tracking a process. Continuing...");
+                                                    Log.Info("An error occurred while tracking a process. Continuing...");
                                                 }
                                                 finally
                                                 {
@@ -1175,36 +1191,36 @@ namespace Microsoft.Crank.Agent
                                 }
                                 catch (Exception e)
                                 {
-                                    Log.WriteLine($"Error starting job '{job.Service}' ({job.Id}): {e}");
+                                    Log.Error(e, $"Error starting job '{job.Service}' ({job.Id})");
 
                                     if (job.State != JobState.Failed)
                                     {
-                                        Log.WriteLine($"{job.State} -> Failed ({job.Service}:{job.Id})");
+                                        Log.Info($"{job.State} -> Failed ({job.Service}:{job.Id})");
                                         job.State = JobState.Failed;
                                     }
                                 }
                             }
                             else if (job.State == JobState.Stopping)
                             {
-                                Log.WriteLine($"Stopping job '{job.Service}' ({job.Id})");
+                                Log.Info($"Stopping job '{job.Service}' ({job.Id})");
 
                                 await StopJobAsync();
                             }
                             else if (job.State == JobState.Stopped)
                             {
-                                Log.WriteLine($"Job '{job.Service}' ({job.Id}) has stopped, waiting for the driver to delete it");
+                                Log.Info($"Job '{job.Service}' ({job.Id}) has stopped, waiting for the driver to delete it");
 
                                 if (DateTime.UtcNow - job.LastDriverCommunicationUtc > DriverTimeout)
                                 {
                                     // The job needs to be deleted
-                                    Log.WriteLine($"Driver didn't communicate for {DriverTimeout}. Halting job.");
-                                    Log.WriteLine($"{job.State} -> Deleting ({job.Service}:{job.Id})");
+                                    Log.Info($"Driver didn't communicate for {DriverTimeout}. Halting job.");
+                                    Log.Info($"{job.State} -> Deleting ({job.Service}:{job.Id})");
                                     job.State = JobState.Deleting;
                                 }
                             }
                             else if (job.State == JobState.Deleting)
                             {
-                                Log.WriteLine($"Deleting job '{job.Service}' ({job.Id})");
+                                Log.Info($"Deleting job '{job.Service}' ({job.Id})");
 
                                 await DeleteJobAsync();
                             }
@@ -1222,8 +1238,8 @@ namespace Microsoft.Crank.Agent
                                         await StopPerfcollectAsync(job, perfCollectProcess);
                                     }
 
-                                    Log.WriteLine("Trace collected");
-                                    Log.WriteLine($"{job.State} -> TraceCollected ({job.Service}:{job.Id})");
+                                    Log.Info("Trace collected");
+                                    Log.Info($"{job.State} -> TraceCollected ({job.Service}:{job.Id})");
                                     job.State = JobState.TraceCollected;
                                 }
 
@@ -1234,7 +1250,7 @@ namespace Microsoft.Crank.Agent
                                     {
                                         if (!dotnetTraceTask.IsCompleted)
                                         {
-                                            Log.WriteLine("Stopping dotnet-trace");
+                                            Log.Info("Stopping dotnet-trace");
 
                                             dotnetTraceManualReset.Set();
 
@@ -1245,21 +1261,21 @@ namespace Microsoft.Crank.Agent
                                         }
 
 
-                                        Log.WriteLine("Trace collected");
+                                        Log.Info("Trace collected");
                                     }
                                     else
                                     {
-                                        Log.WriteLine("Trace collection aborted, dotnet-trace was not started");
+                                        Log.Info("Trace collection aborted, dotnet-trace was not started");
                                     }
 
-                                    Log.WriteLine($"{job.State} -> TraceCollected ({job.Service}:{job.Id})");
+                                    Log.Info($"{job.State} -> TraceCollected ({job.Service}:{job.Id})");
                                     job.State = JobState.TraceCollected;
                                 }
 
                                 // We set the TraceCollected job state after the actual traces when a Dump is collected
                                 if (job.DumpProcess && job.State == JobState.TraceCollecting)
                                 {
-                                    Log.WriteLine($"{job.State} -> TraceCollected ({job.Service}:{job.Id})");
+                                    Log.Info($"{job.State} -> TraceCollected ({job.Service}:{job.Id})");
                                     job.State = JobState.TraceCollected;
                                 }
                             }
@@ -1270,8 +1286,8 @@ namespace Microsoft.Crank.Agent
                                 if (DateTime.UtcNow - job.LastDriverCommunicationUtc > DriverTimeout)
                                 {
                                     // The job needs to be deleted
-                                    Log.WriteLine($"Driver didn't communicate for {DriverTimeout}. Halting job.");
-                                    Log.WriteLine($"{job.State} -> Deleting ({job.Service}:{job.Id})");
+                                    Log.Info($"Driver didn't communicate for {DriverTimeout}. Halting job.");
+                                    Log.Info($"{job.State} -> Deleting ({job.Service}:{job.Id})");
                                     job.State = JobState.Deleting;
                                 }
                             }
@@ -1284,7 +1300,7 @@ namespace Microsoft.Crank.Agent
 
                                 if (DateTime.UtcNow - startMonitorTime > startTimeout)
                                 {
-                                    Log.WriteLine($"Job didn't start during the expected delay");
+                                    Log.Info($"Job didn't start during the expected delay");
                                     job.State = JobState.Failed;
                                     job.Error = "Job didn't start during the expected delay. Check that it outputs a startup message on the log.";
                                 }
@@ -1292,8 +1308,8 @@ namespace Microsoft.Crank.Agent
                                 if (DateTime.UtcNow - job.LastDriverCommunicationUtc > DriverTimeout)
                                 {
                                     // The job needs to be deleted
-                                    Log.WriteLine($"Driver didn't communicate for {DriverTimeout}. Halting job.");
-                                    Log.WriteLine($"{job.State} -> Deleting ({job.Service}:{job.Id})");
+                                    Log.Info($"Driver didn't communicate for {DriverTimeout}. Halting job.");
+                                    Log.Info($"{job.State} -> Deleting ({job.Service}:{job.Id})");
                                     job.State = JobState.Deleting;
                                 }
 
@@ -1304,8 +1320,8 @@ namespace Microsoft.Crank.Agent
                                 if (DateTime.UtcNow - job.LastDriverCommunicationUtc > DriverTimeout)
                                 {
                                     // The job needs to be deleted
-                                    Log.WriteLine($"Driver didn't communicate for {DriverTimeout}. Halting job.");
-                                    Log.WriteLine($"{job.State} -> Deleting ({job.Service}:{job.Id})");
+                                    Log.Info($"Driver didn't communicate for {DriverTimeout}. Halting job.");
+                                    Log.Info($"{job.State} -> Deleting ({job.Service}:{job.Id})");
                                     job.State = JobState.Deleting;
                                 }
                             }
@@ -1313,9 +1329,9 @@ namespace Microsoft.Crank.Agent
                             void StopCounters()
                             {
                                 // Releasing Counters
-                                
-                                Log.WriteLine($"Stopping counters event pipes for job '{job.Service}' ({job.Id})");
-                                
+
+                                Log.Info($"Stopping counters event pipes for job '{job.Service}' ({job.Id})");
+
                                 try
                                 {
                                     if (context.CountersTask != null && context.CountersCompletionSource != null)
@@ -1326,19 +1342,19 @@ namespace Microsoft.Crank.Agent
 
                                         if (!context.CountersTask.IsCompleted)
                                         {
-                                            Log.WriteLine($"[ERROR] Counters could not be stopped in time for job '{job.Service}' ({job.Id})");
+                                            Log.Error($"[ERROR] Counters could not be stopped in time for job '{job.Service}' ({job.Id})");
                                         }
-                                        
-                                        Log.WriteLine($"Counters stopped for job '{job.Service}' ({job.Id})");
+
+                                        Log.Info($"Counters stopped for job '{job.Service}' ({job.Id})");
                                     }
                                     else
                                     {
-                                        Log.WriteLine($"[WARNING] No event source open for job '{job.Service}' ({job.Id})");
+                                        Log.Warning($"[WARNING] No event source open for job '{job.Service}' ({job.Id})");
                                     }
                                 }
                                 catch (Exception e)
                                 {
-                                    Log.WriteLine("Error in StopCounters(): " + e.ToString());
+                                    Log.Error(e, "Error in StopCounters(): ");
                                 }
                                 finally
                                 {
@@ -1358,7 +1374,7 @@ namespace Microsoft.Crank.Agent
                                 // Collect dump
                                 if (job.DumpProcess)
                                 {
-                                    Log.WriteLine($"Collecting dump ({job.Service}:{job.Id})");
+                                    Log.Info($"Collecting dump ({job.Service}:{job.Id})");
 
                                     job.DumpFile = Path.GetTempFileName();
 
@@ -1366,19 +1382,18 @@ namespace Microsoft.Crank.Agent
                                     dumper.Collect(job.ChildProcessId > 0 ? job.ChildProcessId : job.ProcessId, job.DumpFile, job.DumpType);
                                 }
 
-                                Log.WriteLine($"Stopping heartbeat ({job.Service}:{job.Id})");
-                                    
+                                Log.Info($"Stopping heartbeat ({job.Service}:{job.Id})");
+
                                 Monitor.Enter(_synLock);
 
                                 try
                                 {
                                     context.Timer?.Dispose();
-                                    Log.WriteLine($"Heartbeat stopped for ({job.Service}:{job.Id})");
+                                    Log.Info($"Heartbeat stopped for ({job.Service}:{job.Id})");
                                 }
                                 catch (Exception e)
                                 {
-                                    Log.WriteLine($"[ERROR] Heartbeat failed to stop for ({job.Service}:{job.Id})");
-                                    Log.WriteLine(e.ToString());
+                                    Log.Error(e, $"[ERROR] Heartbeat failed to stop for ({job.Service}:{job.Id})");
                                 }
                                 finally
                                 {
@@ -1426,7 +1441,7 @@ namespace Microsoft.Crank.Agent
                                             {
                                                 if (!dotnetTraceTask.IsCompleted)
                                                 {
-                                                    Log.WriteLine("Stopping dotnet-trace");
+                                                    Log.Info("Stopping dotnet-trace");
 
                                                     dotnetTraceManualReset.Set();
 
@@ -1441,7 +1456,7 @@ namespace Microsoft.Crank.Agent
 
                                     if (OperatingSystem == OperatingSystem.Linux)
                                     {
-                                        Log.WriteLine($"Invoking SIGTERM ...");
+                                        Log.Info($"Invoking SIGTERM ...");
 
                                         Mono.Unix.Native.Syscall.kill(process.Id, Mono.Unix.Native.Signum.SIGTERM);
 
@@ -1453,7 +1468,7 @@ namespace Microsoft.Crank.Agent
 
                                         if (!process.HasExited)
                                         {
-                                            Log.WriteLine($"Invoking SIGINT ...");
+                                            Log.Info($"Invoking SIGINT ...");
 
                                             Mono.Unix.Native.Syscall.kill(process.Id, Mono.Unix.Native.Signum.SIGINT);
 
@@ -1469,11 +1484,11 @@ namespace Microsoft.Crank.Agent
                                     {
                                         if (!process.HasExited)
                                         {
-                                            Log.WriteLine($"Sending CTRL+C ...");
+                                            Log.Info($"Sending CTRL+C ...");
 
                                             // Disable CTRL handling for the Agent, or the CTRL+C would stop it too
                                             SetConsoleCtrlHandler(null, true);
-                                            GenerateConsoleCtrlEvent(CtrlTypes.CTRL_C_EVENT, (uint) process.Id);
+                                            GenerateConsoleCtrlEvent(CtrlTypes.CTRL_C_EVENT, (uint)process.Id);
 
                                             var waitForShutdownDelay = Task.Delay(TimeSpan.FromSeconds(5));
                                             while (!process.HasExited && !waitForShutdownDelay.IsCompletedSuccessfully)
@@ -1500,7 +1515,7 @@ namespace Microsoft.Crank.Agent
 
                                                 do
                                                 {
-                                                    Log.WriteLine($"Shutdown successfully invoked, waiting for graceful shutdown ...");
+                                                    Log.Info($"Shutdown successfully invoked, waiting for graceful shutdown ...");
                                                     await Task.Delay(1000);
 
                                                 } while (!process.HasExited && (DateTime.UtcNow - epoch < TimeSpan.FromSeconds(5)));
@@ -1508,13 +1523,13 @@ namespace Microsoft.Crank.Agent
                                         }
                                         catch
                                         {
-                                            Log.WriteLine($"/shutdown endpoint failed... '{job.Url}/shutdown'");
+                                            Log.Info($"/shutdown endpoint failed... '{job.Url}/shutdown'");
                                         }
                                     }
 
                                     if (!process.HasExited)
                                     {
-                                        Log.WriteLine($"Forcing process to stop ...");
+                                        Log.Info($"Forcing process to stop ...");
                                         process.CloseMainWindow();
 
                                         if (!process.HasExited)
@@ -1526,7 +1541,7 @@ namespace Microsoft.Crank.Agent
 
                                         do
                                         {
-                                            Log.WriteLine($"Waiting for process {processId} to stop ...");
+                                            Log.Info($"Waiting for process {processId} to stop ...");
 
                                             await Task.Delay(1000);
 
@@ -1547,7 +1562,7 @@ namespace Microsoft.Crank.Agent
                                         job.ExitCode = process.ExitCode;
                                     }
 
-                                    Log.WriteLine($"Process has stopped");
+                                    Log.Info($"Process has stopped");
 
 
                                     job.State = JobState.Stopped;
@@ -1569,7 +1584,7 @@ namespace Microsoft.Crank.Agent
                                     // if there is an AfterScript
                                 }
 
-                                Log.WriteLine($"Process stopped ({job.State})");
+                                Log.Info($"Process stopped ({job.State})");
                             }
 
                             async Task DeleteJobAsync()
@@ -1590,7 +1605,7 @@ namespace Microsoft.Crank.Agent
 
                                 tempDir = null;
 
-                                Log.WriteLine($"{job.State} -> Deleted ({job.Service}:{job.Id})");
+                                Log.Info($"{job.State} -> Deleted ({job.Service}:{job.Id})");
 
                                 job.State = JobState.Deleted;
                             }
@@ -1620,7 +1635,7 @@ namespace Microsoft.Crank.Agent
             }
             catch (Exception e)
             {
-                Log.WriteLine($"Unexpected error: {e}");
+                Log.Error(e, $"Unexpected error");
             }
         }
 
@@ -1628,11 +1643,11 @@ namespace Microsoft.Crank.Agent
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                Log.WriteLine($"PerfView is only supported on Windows");
+                Log.Info($"PerfView is only supported on Windows");
                 return null;
             }
 
-            Log.WriteLine($"Starting process '{_perfviewPath} {arguments}' in '{workingDirectory}'");
+            Log.Info($"Starting process '{_perfviewPath} {arguments}' in '{workingDirectory}'");
 
             var process = new Process()
             {
@@ -1654,7 +1669,7 @@ namespace Microsoft.Crank.Agent
             {
                 if (e != null && e.Data != null)
                 {
-                    Log.WriteLine(e.Data);
+                    Log.Info(e.Data);
 
                     if (e.Data.Contains("Press enter to close window"))
                     {
@@ -1682,7 +1697,7 @@ namespace Microsoft.Crank.Agent
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                Log.WriteLine($"PerfCollect is only supported on Linux");
+                Log.Info($"PerfCollect is only supported on Linux");
                 return null;
             }
 
@@ -1701,35 +1716,35 @@ namespace Microsoft.Crank.Agent
             {
                 if (e != null && e.Data != null)
                 {
-                    Log.WriteLine(e.Data);
+                    Log.Info(e.Data);
                 }
             };
 
             process.Start();
             process.BeginOutputReadLine();
 
-            Log.WriteLine($"Perfcollect started [{process.Id}]");
+            Log.Info($"Perfcollect started [{process.Id}]");
 
             return process;
         }
 
-        private static async Task StopPerfcollectAsync(Job job,Process perfCollectProcess)
+        private static async Task StopPerfcollectAsync(Job job, Process perfCollectProcess)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                Log.WriteLine($"PerfCollect is only supported on Linux");
+                Log.Info($"PerfCollect is only supported on Linux");
                 return;
             }
 
             if (perfCollectProcess == null || perfCollectProcess.HasExited)
             {
-                Log.WriteLine($"PerfCollect is not running");
+                Log.Info($"PerfCollect is not running");
                 return;
             }
 
             var processId = perfCollectProcess.Id;
 
-            Log.WriteLine($"Stopping PerfCollect");
+            Log.Info($"Stopping PerfCollect");
 
             Mono.Unix.Native.Syscall.kill(processId, Mono.Unix.Native.Signum.SIGINT);
 
@@ -1748,7 +1763,7 @@ namespace Microsoft.Crank.Agent
 
             if (!perfCollectProcess.HasExited)
             {
-                Log.WriteLine($"PerfCollect exceeded allowed time, stopping ...");
+                Log.Info($"PerfCollect exceeded allowed time, stopping ...");
                 perfCollectProcess.CloseMainWindow();
 
                 if (!perfCollectProcess.HasExited)
@@ -1760,7 +1775,7 @@ namespace Microsoft.Crank.Agent
 
                 do
                 {
-                    Log.WriteLine($"Waiting for process {processId} to stop ...");
+                    Log.Info($"Waiting for process {processId} to stop ...");
 
                     await Task.Delay(1000);
 
@@ -1777,7 +1792,7 @@ namespace Microsoft.Crank.Agent
                 } while (perfCollectProcess != null && !perfCollectProcess.HasExited);
             }
 
-            Log.WriteLine($"PerfCollect process has stopped");
+            Log.Info($"PerfCollect process has stopped");
 
             perfCollectProcess = null;
 
@@ -1785,7 +1800,7 @@ namespace Microsoft.Crank.Agent
 
         private static void ConvertLines(string path)
         {
-            Log.WriteLine($"Converting '{path}' ...");
+            Log.Info($"Converting '{path}' ...");
 
             var content = File.ReadAllText(path);
 
@@ -1817,7 +1832,7 @@ namespace Microsoft.Crank.Agent
                     || options.Repository != job.Source.Repository
                     || options.BranchOrCommit != job.Source.BranchOrCommit)
                     {
-                        Log.WriteLine("[INFO] Ignoring existing source folder as it's not matching the request source settings");
+                        Log.Info("[INFO] Ignoring existing source folder as it's not matching the request source settings");
                         reuseFolder = false;
                     }
                     else
@@ -1827,12 +1842,12 @@ namespace Microsoft.Crank.Agent
                         var localRepositoryFolder = new DirectoryInfo(Directory.GetDirectories(path).FirstOrDefault(x => !x.EndsWith("buildtools"))).Name;
                         srcDir = Path.Combine(path, localRepositoryFolder);
 
-                        Log.WriteLine($"Reusing cloned repository in {srcDir}");
+                        Log.Info($"Reusing cloned repository in {srcDir}");
                     }
                 }
                 else
                 {
-                    Log.WriteLine($"Creating reuse options.json file");
+                    Log.Info($"Creating reuse options.json file");
 
                     // First time using this folder
                     File.WriteAllText(optionsPath, JsonConvert.SerializeObject(job.Source));
@@ -1849,14 +1864,14 @@ namespace Microsoft.Crank.Agent
 
                 if (!reuseFolder)
                 {
-                    Log.WriteLine($"Extracting source code to {srcDir}");
+                    Log.Info($"Extracting source code to {srcDir}");
 
                     ZipFile.ExtractToDirectory(job.Source.SourceCode.TempFilename, srcDir);
                 
                     // Convert CRLF to LF on Linux
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                     {
-                        Log.WriteLine($"Converting text files ...");
+                        Log.Info($"Converting text files ...");
 
                         foreach (var file in Directory.GetFiles(srcDir + Path.DirectorySeparatorChar, "*.*", SearchOption.AllDirectories))
                         {
@@ -1911,7 +1926,7 @@ namespace Microsoft.Crank.Agent
             {
                 var filename = Path.Combine(srcDir, attachment.Filename.Replace("\\", "/"));
 
-                Log.WriteLine($"Creating build file: {filename}");
+                Log.Info($"Creating build file: {filename}");
 
                 if (File.Exists(filename))
                 {
@@ -1931,7 +1946,7 @@ namespace Microsoft.Crank.Agent
 
             if (!requireBuild)
             {
-                Log.WriteLine("Skipping build step, reusing previous build");
+                Log.Info("Skipping build step, reusing previous build");
             }
             else
                 {
@@ -1984,7 +1999,7 @@ namespace Microsoft.Crank.Agent
                         log: true,
                         outputDataReceived: text => job.BuildLog.AddLine(text));
 
-                    if(long.TryParse(inspectResults.StandardOutput.Trim(), out var imageSize))
+                    if (long.TryParse(inspectResults.StandardOutput.Trim(), out var imageSize))
                     {
                         if (imageSize != 0)
                         {
@@ -2003,15 +2018,15 @@ namespace Microsoft.Crank.Agent
                 }
                 else
                 {
-                    Log.WriteLine($"Loading docker image {source.DockerLoad} from {srcDir}");
+                    Log.Info($"Loading docker image {source.DockerLoad} from {srcDir}");
 
                     var dockerLoadArguments = $"load -i {source.DockerLoad} ";
 
                     job.BuildLog.AddLine("docker " + dockerLoadArguments);
 
-                    await ProcessUtil.RunAsync("docker", dockerLoadArguments, 
-                        workingDirectory: srcDir, 
-                        cancellationToken: cancellationToken, 
+                    await ProcessUtil.RunAsync("docker", dockerLoadArguments,
+                        workingDirectory: srcDir,
+                        cancellationToken: cancellationToken,
                         log: true,
                         outputDataReceived: text => job.BuildLog.AddLine(text)
                     );
@@ -2063,7 +2078,7 @@ namespace Microsoft.Crank.Agent
 
             job.Url = ComputeServerUrl(hostname, job);
 
-            Log.WriteLine($"Intercepting Docker logs for '{containerId}' ...");
+            Log.Info($"Intercepting Docker logs for '{containerId}' ...");
 
             var process = new Process()
             {
@@ -2092,19 +2107,19 @@ namespace Microsoft.Crank.Agent
 
             if (!String.IsNullOrEmpty(job.ReadyStateText))
             {
-                Log.WriteLine($"Waiting for startup signal: '{job.ReadyStateText}'...");
+                Log.Info($"Waiting for startup signal: '{job.ReadyStateText}'...");
 
                 process.OutputDataReceived += (_, e) =>
                 {
                     if (e != null && e.Data != null)
                     {
-                        Log.WriteLine(e.Data);
+                        Log.Info(e.Data);
 
                         job.Output.AddLine(e.Data);
 
                         if (job.State == JobState.Starting && e.Data.IndexOf(job.ReadyStateText, StringComparison.OrdinalIgnoreCase) >= 0)
                         {
-                            Log.WriteLine($"Ready state detected, application is now running...");
+                            Log.Info($"Ready state detected, application is now running...");
                             MarkAsRunning(hostname, job, stopwatch);
 
                             if (job.Collect && !job.CollectStartup)
@@ -2122,13 +2137,13 @@ namespace Microsoft.Crank.Agent
                 {
                     if (e != null && e.Data != null)
                     {
-                        Log.WriteLine("[STDERR] " + e.Data);
+                        Log.Info("[STDERR] " + e.Data);
 
                         job.Output.AddLine("[STDERR] " + e.Data);
 
                         if (job.State == JobState.Starting && e.Data.IndexOf(job.ReadyStateText, StringComparison.OrdinalIgnoreCase) >= 0)
                         {
-                            Log.WriteLine($"Ready state detected, application is now running...");
+                            Log.Info($"Ready state detected, application is now running...");
                             MarkAsRunning(hostname, job, stopwatch);
 
                             if (job.Collect && !job.CollectStartup)
@@ -2141,13 +2156,13 @@ namespace Microsoft.Crank.Agent
             }
             else
             {
-                Log.WriteLine($"Trying to contact the application ...");
+                Log.Info($"Trying to contact the application ...");
 
                 process.OutputDataReceived += (_, e) =>
                 {
                     if (e != null && e.Data != null)
                     {
-                        Log.WriteLine(e.Data);
+                        Log.Info(e.Data);
                         job.Output.AddLine(e.Data);
 
                         ParseMeasurementOutput(job, job.Output);
@@ -2159,11 +2174,11 @@ namespace Microsoft.Crank.Agent
                 // will fail to connect and the job will be cleaned up properly
                 if (await WaitToListen(job, hostname, 30))
                 {
-                    Log.WriteLine($"Application is responding...");
+                    Log.Info($"Application is responding...");
                 }
                 else
                 {
-                    Log.WriteLine($"Application MAY be running, continuing...");
+                    Log.Info($"Application MAY be running, continuing...");
                 }
 
                 MarkAsRunning(hostname, job, stopwatch);
@@ -2200,12 +2215,12 @@ namespace Microsoft.Crank.Agent
 
                 if (startIndex == lines.Length - 1)
                 {
-                    Log.WriteLine($"Didn't find start of statistics");
+                    Log.Info($"Didn't find start of statistics");
                     return;
                 }
                 else
                 {
-                    Log.WriteLine($"Parsing custom measures...");
+                    Log.Info($"Parsing custom measures...");
                 }
 
                 var jsonStatistics = String.Join(Environment.NewLine, lines.Skip(startIndex + 1).Take(lines.Length - startIndex - 2));
@@ -2214,7 +2229,7 @@ namespace Microsoft.Crank.Agent
                 {
                     var jobStatistics = JsonConvert.DeserializeObject<JobStatistics>(jsonStatistics);
 
-                    Log.WriteLine($"Found {jobStatistics.Metadata.Count} metadata and {jobStatistics.Measurements.Count} measurements");
+                    Log.Info($"Found {jobStatistics.Metadata.Count} metadata and {jobStatistics.Measurements.Count} measurements");
 
                     foreach (var metadata in jobStatistics.Metadata)
                     {
@@ -2228,7 +2243,7 @@ namespace Microsoft.Crank.Agent
                 }
                 catch (Exception e)
                 {
-                    Log.WriteLine($"[ERROR] Invalid Json payload: " + e.Message);
+                    Log.Error(e, "[ERROR] Invalid Json payload: ");
                 }
             }
         }
@@ -2237,11 +2252,11 @@ namespace Microsoft.Crank.Agent
         {
             if (job.IsConsoleApp)
             {
-                Log.WriteLine($"Console application detected, not waiting");
+                Log.Info($"Console application detected, not waiting");
                 return true;
             }
 
-            Log.WriteLine($"Polling server on {hostname}:{job.Port}");
+            Log.Info($"Polling server on {hostname}:{job.Port}");
 
             for (var i = 1; i <= maxRetries; ++i)
             {
@@ -2253,11 +2268,11 @@ namespace Microsoft.Crank.Agent
                         await Task.WhenAny(connectTask, Task.Delay(1000));
                         if (connectTask.IsCompleted)
                         {
-                            Log.WriteLine($"Success!");
+                            Log.Info($"Success!");
                             return true;
                         }
 
-                        Log.WriteLine($"Attempt #{i} failed...");
+                        Log.Info($"Attempt #{i} failed...");
                     }
                 }
                 catch
@@ -2286,7 +2301,7 @@ namespace Microsoft.Crank.Agent
 
                     if (exitCode.Trim() != "0")
                     {
-                        Log.WriteLine("Job failed");
+                        Log.Info("Job failed");
                         job.Error = job.Output.ToString();
                         finalState = JobState.Failed;
                     }
@@ -2300,30 +2315,30 @@ namespace Microsoft.Crank.Agent
             {
                 try
                 {
-                    Log.WriteLine($"Removing container {containerId}");
+                    Log.Info($"Removing container {containerId}");
 
                     await ProcessUtil.RunAsync("docker", $"rm --force {containerId}", throwOnError: false);
 
                     if (!String.IsNullOrEmpty(job.Source.SourceKey) && job.Source.NoBuild)
                     {
-                        Log.WriteLine($"Keeping image {imageName}");
+                        Log.Info($"Keeping image {imageName}");
                     }
                     else if (job.NoClean)
                     {
-                        Log.WriteLine($"Removing image {imageName}");
-                    
+                        Log.Info($"Removing image {imageName}");
+
                         // --no-prune: Do not delete untagged parents
                         await ProcessUtil.RunAsync("docker", $"rmi --force --no-prune {imageName}", throwOnError: false);
                     }
                     else
-                    {                        
-                        Log.WriteLine($"Removing image {imageName} and its parents");
+                    {
+                        Log.Info($"Removing image {imageName} and its parents");
                         await ProcessUtil.RunAsync("docker", $"rmi --force {imageName}", throwOnError: false);
                     }
                 }
                 catch (Exception e)
                 {
-                    Log.WriteLine("An error occurred while deleting the docker container: " + e.Message);
+                    Log.Error(e, "An error occurred while deleting the docker container: " + e.Message);
                     finalState = JobState.Failed;
                 }
                 finally
@@ -2354,7 +2369,7 @@ namespace Microsoft.Crank.Agent
                     || options.Repository != job.Source.Repository
                     || options.BranchOrCommit != job.Source.BranchOrCommit)
                     {
-                        Log.WriteLine("[INFO] Ignoring existing source folder as it's not matching the request source settings");
+                        Log.Info("[INFO] Ignoring existing source folder as it's not matching the request source settings");
                         reuseFolder = false;
                     }
                     else
@@ -2384,12 +2399,12 @@ namespace Microsoft.Crank.Agent
 
                     if (String.IsNullOrEmpty(job.Executable))
                     {
-                        Log.WriteLine($"Extracting files to {src}");
+                        Log.Info($"Extracting files to {src}");
                         ZipFile.ExtractToDirectory(job.Source.SourceCode.TempFilename, src);
                     }
                     else
                     {
-                        Log.WriteLine($"Extracting files to {published}");
+                        Log.Info($"Extracting files to {published}");
                         ZipFile.ExtractToDirectory(job.Source.SourceCode.TempFilename, published);
                     }
 
@@ -2447,7 +2462,7 @@ namespace Microsoft.Crank.Agent
                 benchmarkedApp = Path.Combine(benchmarkedApp, Path.GetDirectoryName(FormatPathSeparators(job.Source.Project)));
             }
 
-            Log.WriteLine($"Benchmarked Application in {benchmarkedApp}");
+            Log.Info($"Benchmarked Application in {benchmarkedApp}");
 
             var commitHash = await Git.CommitHashAsync(benchmarkedApp, cancellationToken);
 
@@ -2459,7 +2474,7 @@ namespace Microsoft.Crank.Agent
 
             if (!requireDotnetBuild)
             {
-                Log.WriteLine("Skipping build step, no required");
+                Log.Info("Skipping build step, no required");
                 return benchmarkedDir;
             }
 
@@ -2468,7 +2483,7 @@ namespace Microsoft.Crank.Agent
 
             if (!requireDotnetBuild)
             {
-                Log.WriteLine("Skipping build step, reusing previous build");
+                Log.Info("Skipping build step, reusing previous build");
                 return benchmarkedDir;
             }
 
@@ -2478,7 +2493,7 @@ namespace Microsoft.Crank.Agent
                 ["DOTNET_ROOT"] = dotnetHome,
             };
 
-            Log.WriteLine("Downloading build tools");
+            Log.Info("Downloading build tools");
 
             // Install latest SDK and runtime
             // * Use custom install dir to avoid changing the default install, which is impossible if other processes
@@ -2489,7 +2504,7 @@ namespace Microsoft.Crank.Agent
                 Directory.CreateDirectory(buildToolsPath);
             }
 
-            Log.WriteLine($"Installing dotnet runtimes and sdk");
+            Log.Info($"Installing dotnet runtimes and sdk");
 
             // Define which Runtime and SDK will be installed.
 
@@ -2509,7 +2524,7 @@ namespace Microsoft.Crank.Agent
             if (!String.IsNullOrEmpty(job.Framework))
             {
                 targetFramework = job.Framework;
-                Log.WriteLine($"Specific target framework: '{targetFramework}'");
+                Log.Info($"Specific target framework: '{targetFramework}'");
             }
 
             // If no version is set for runtime, check project's default tfm
@@ -2583,7 +2598,7 @@ namespace Microsoft.Crank.Agent
                     if (!_installedSdks.Contains(sdkVersion))
                     {
                         dotnetInstallStep = $"SDK '{sdkVersion}'";
-                        Log.WriteLine($"Installing {dotnetInstallStep} ...");
+                        Log.Info($"Installing {dotnetInstallStep} ...");
 
                         // Install latest SDK version (and associated runtime)
 
@@ -2612,7 +2627,7 @@ namespace Microsoft.Crank.Agent
                     if (!_installedDotnetRuntimes.Contains(runtimeVersion))
                     {
                         dotnetInstallStep = $"Runtime '{runtimeVersion}'";
-                        Log.WriteLine($"Installing {dotnetInstallStep} ...");
+                        Log.Info($"Installing {dotnetInstallStep} ...");
 
                         // Install runtimes required for this scenario
 
@@ -2650,7 +2665,7 @@ namespace Microsoft.Crank.Agent
                                 && !_ignoredDesktopRuntimes.Contains(desktopVersion))
                             {
                                 dotnetInstallStep = $"Desktop runtime '{desktopVersion}'";
-                                Log.WriteLine($"Installing {dotnetInstallStep} ...");
+                                Log.Info($"Installing {dotnetInstallStep} ...");
 
                                 dotnetFeed = GetAzureFeedForVersion(desktopVersion);
 
@@ -2696,7 +2711,7 @@ namespace Microsoft.Crank.Agent
                     if (installAspNetSharedFramework && !_installedAspNetRuntimes.Contains(aspNetCoreVersion))
                     {
                         dotnetInstallStep = $"ASP.NET runtime '{aspNetCoreVersion}'";
-                        Log.WriteLine($"Installing {dotnetInstallStep} ...");
+                        Log.Info($"Installing {dotnetInstallStep} ...");
 
                         // Install aspnet runtime required for this scenario
 
@@ -2727,7 +2742,7 @@ namespace Microsoft.Crank.Agent
                     if (!_installedSdks.Contains(sdkVersion))
                     {
                         dotnetInstallStep = $"SDK '{sdkVersion}'";
-                        Log.WriteLine($"Installing {dotnetInstallStep} ...");
+                        Log.Info($"Installing {dotnetInstallStep} ...");
 
                         // Install latest SDK version (and associated runtime)
 
@@ -2756,7 +2771,7 @@ namespace Microsoft.Crank.Agent
                     if (!_installedDotnetRuntimes.Contains(runtimeVersion))
                     {
                         dotnetInstallStep = $"Runtime '{runtimeVersion}'";
-                        Log.WriteLine($"Installing {dotnetInstallStep} ...");
+                        Log.Info($"Installing {dotnetInstallStep} ...");
 
                         // Install required runtime
 
@@ -2786,7 +2801,7 @@ namespace Microsoft.Crank.Agent
                     if (installAspNetSharedFramework && !_installedAspNetRuntimes.Contains(aspNetCoreVersion))
                     {
                         dotnetInstallStep = $"ASP.NET runtime '{aspNetCoreVersion}'";
-                        Log.WriteLine($"Installing {dotnetInstallStep} ...");
+                        Log.Info($"Installing {dotnetInstallStep} ...");
 
                         // Install required runtime
 
@@ -2885,7 +2900,7 @@ namespace Microsoft.Crank.Agent
                 }
                 catch (Exception e)
                 {
-                    Log.WriteLine("[ERROR] Could not record AspNetCoreVersion:" + e.ToString());
+                    Log.Error(e, "[ERROR] Could not record AspNetCoreVersion:");
                 }
             }
 
@@ -2918,7 +2933,7 @@ namespace Microsoft.Crank.Agent
                 }
                 catch (Exception e)
                 {
-                    Log.WriteLine("[ERROR] Could not record NetCoreAppVersion:" + e.ToString());
+                    Log.Error(e, "[ERROR] Could not record NetCoreAppVersion:");
                 }
             }
 
@@ -3013,7 +3028,7 @@ namespace Microsoft.Crank.Agent
             {
                 var filename = Path.Combine(benchmarkedApp, attachment.Filename.Replace("\\", "/"));
 
-                Log.WriteLine($"Creating build file: {filename}");
+                Log.Info($"Creating build file: {filename}");
 
                 if (File.Exists(filename))
                 {
@@ -3041,8 +3056,8 @@ namespace Microsoft.Crank.Agent
                 env["MSBuildSDKsPath"] = Path.Combine(Path.GetDirectoryName(dotnetExecutable), $"sdk/{sdkVersion}/Sdks");
                 env["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
 
-                Log.WriteLine($"Working directory: {benchmarkedApp}");
-                Log.WriteLine($"Command line: {dotnetExecutable} {arguments}");
+                Log.Info($"Working directory: {benchmarkedApp}");
+                Log.Info($"Command line: {dotnetExecutable} {arguments}");
 
                 var stopwatch = new Stopwatch();
                 stopwatch.Start();
@@ -3081,7 +3096,7 @@ namespace Microsoft.Crank.Agent
                     Value = stopwatch.ElapsedMilliseconds
                 });
 
-                Log.WriteLine($"Application published successfully in {job.BuildTime.TotalMilliseconds} ms");
+                Log.Info($"Application published successfully in {job.BuildTime.TotalMilliseconds} ms");
 
                 PatchRuntimeConfig(job, outputFolder, aspNetCoreVersion, runtimeVersion);
             }
@@ -3100,7 +3115,7 @@ namespace Microsoft.Crank.Agent
                 });
             }
 
-            Log.WriteLine($"Published size: {job.PublishedSize}");
+            Log.Info($"Published size: {job.PublishedSize}");
 
             // Copy crossgen in the app folder
             if (job.Collect && OperatingSystem == OperatingSystem.Linux)
@@ -3108,7 +3123,7 @@ namespace Microsoft.Crank.Agent
                 // https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.netcore.app.runtime.linux-x64/index.json
                 // This is because the package names were changed.For 3.0 +, look for ~/.nuget/packages/microsoft.netcore.app.runtime.linux-x64/<version>/tools/crossgen.
 
-                Log.WriteLine("Copying crossgen to application folder");
+                Log.Info("Copying crossgen to application folder");
 
                 try
                 {
@@ -3120,7 +3135,7 @@ namespace Microsoft.Crank.Agent
 
                     if (!File.Exists(runtimePath))
                     {
-                        Log.WriteLine($"Downloading runtime package");
+                        Log.Info($"Downloading runtime package");
 
                         var found = false;
                         foreach (var feed in _runtimeFeedUrls)
@@ -3146,7 +3161,7 @@ namespace Microsoft.Crank.Agent
                     }
                     else
                     {
-                        Log.WriteLine($"Found runtime package at '{runtimePath}'");
+                        Log.Info($"Found runtime package at '{runtimePath}'");
                     }
 
                     using (var archive = ZipFile.OpenRead(runtimePath))
@@ -3168,7 +3183,7 @@ namespace Microsoft.Crank.Agent
                                     Directory.CreateDirectory(Path.GetDirectoryName(crossgenFilename));
 
                                     entry.ExtractToFile(crossgenFilename);
-                                    Log.WriteLine($"Copied crossgen to {crossgenFolder}");
+                                    Log.Info($"Copied crossgen to {crossgenFolder}");
                                 }
 
                                 break;
@@ -3178,10 +3193,10 @@ namespace Microsoft.Crank.Agent
                 }
                 catch (Exception e)
                 {
-                    Log.WriteLine("ERROR: Failed to download crossgen. " + e.ToString());
+                    Log.Error(e, "ERROR: Failed to download crossgen. ");
                 }
 
-                Log.WriteLine("Downloading symbols");
+                Log.Info("Downloading symbols");
 
                 var symbolsFolder = job.SelfContained
                     ? outputFolder
@@ -3213,7 +3228,7 @@ namespace Microsoft.Crank.Agent
             {
                 var filename = Path.Combine(outputFolder, attachment.Filename.Replace("\\", "/"));
 
-                Log.WriteLine($"Creating output file: {filename}");
+                Log.Info($"Creating output file: {filename}");
 
                 if (File.Exists(filename))
                 {
@@ -3329,7 +3344,7 @@ namespace Microsoft.Crank.Agent
 
                 if (assemblyNameElement != null)
                 {
-                    Log.WriteLine($"Detected custom assembly name: '{assemblyNameElement.Value}'");
+                    Log.Info($"Detected custom assembly name: '{assemblyNameElement.Value}'");
                     return assemblyNameElement.Value;
                 }
             }
@@ -3351,7 +3366,7 @@ namespace Microsoft.Crank.Agent
                 {
                     targetFramework = targetFrameworkElement.Value;
 
-                    Log.WriteLine($"Detected target framework: '{targetFramework}'");
+                    Log.Info($"Detected target framework: '{targetFramework}'");
                 }
                 else
                 {
@@ -3365,13 +3380,13 @@ namespace Microsoft.Crank.Agent
                     {
                         targetFramework = targetFrameworksElement.Value.Split(';').FirstOrDefault();
 
-                        Log.WriteLine($"Detected target framework: '{targetFramework}'");
+                        Log.Info($"Detected target framework: '{targetFramework}'");
                     }
                 }
             }
             else
             {
-                Log.WriteLine($"Project file not found: '{projectFileName}'");
+                Log.Info($"Project file not found: '{projectFileName}'");
             }
 
             return targetFramework;
@@ -3388,7 +3403,7 @@ namespace Microsoft.Crank.Agent
 
             if (File.Exists(projectFileName))
             {
-                Log.WriteLine("Patching project file with Framework References");
+                Log.Info("Patching project file with Framework References");
 
                 await ProcessUtil.RetryOnExceptionAsync(3, async () =>
                 {
@@ -3551,7 +3566,7 @@ namespace Microsoft.Crank.Agent
             if (String.Equals(aspNetCoreVersion, "Current", StringComparison.OrdinalIgnoreCase))
             {
                 aspNetCoreVersion = currentAspNetCoreVersion;
-                Log.WriteLine($"ASP.NET: {aspNetCoreVersion} (Current)");
+                Log.Info($"ASP.NET: {aspNetCoreVersion} (Current)");
             }
             else if (String.Equals(aspNetCoreVersion, "Latest", StringComparison.OrdinalIgnoreCase)
                 || String.Equals(aspNetCoreVersion, "Edge", StringComparison.OrdinalIgnoreCase))
@@ -3560,27 +3575,27 @@ namespace Microsoft.Crank.Agent
                 if (versionPrefix == "7.0")
                 {
                     aspNetCoreVersion = await GetFlatContainerVersion(_aspnet7FlatContainerUrl, versionPrefix, checkDotnetInstallUrl: true);
-                    Log.WriteLine($"ASP.NET: {aspNetCoreVersion} (Latest - From 7.0 feed)");
+                    Log.Info($"ASP.NET: {aspNetCoreVersion} (Latest - From 7.0 feed)");
                 }
                 else if (versionPrefix == "6.0")
                 {
                     aspNetCoreVersion = await GetFlatContainerVersion(_aspnet6FlatContainerUrl, versionPrefix, checkDotnetInstallUrl: true);
-                    Log.WriteLine($"ASP.NET: {aspNetCoreVersion} (Latest - From 6.0 feed)");
+                    Log.Info($"ASP.NET: {aspNetCoreVersion} (Latest - From 6.0 feed)");
                 }
                 else if (versionPrefix == "5.0")
                 {
                     aspNetCoreVersion = await GetFlatContainerVersion(_aspnet5FlatContainerUrl, versionPrefix);
-                    Log.WriteLine($"ASP.NET: {aspNetCoreVersion} (Latest - From 5.0 feed)");
+                    Log.Info($"ASP.NET: {aspNetCoreVersion} (Latest - From 5.0 feed)");
                 }
                 else
                 {
                     aspNetCoreVersion = currentAspNetCoreVersion;
-                    Log.WriteLine($"ASP.NET: {aspNetCoreVersion} (Latest - Fallback on Current)");
+                    Log.Info($"ASP.NET: {aspNetCoreVersion} (Latest - Fallback on Current)");
                 }
             }
             else
             {
-                Log.WriteLine($"ASP.NET: {aspNetCoreVersion} (Specific)");
+                Log.Info($"ASP.NET: {aspNetCoreVersion} (Specific)");
             }
 
             return aspNetCoreVersion;
@@ -3605,16 +3620,16 @@ namespace Microsoft.Crank.Agent
             {
                 if (!File.Exists(globalJsonFilename))
                 {
-                    Log.WriteLine($"Could not find global.json file");
+                    Log.Info($"Could not find global.json file");
                 }
                 else
                 {
-                    Log.WriteLine($"Searching SDK version in global.json");
+                    Log.Info($"Searching SDK version in global.json");
 
                     var globalObject = JObject.Parse(File.ReadAllText(globalJsonFilename));
                     sdkVersion = globalObject["sdk"]["version"].ToString();
 
-                    Log.WriteLine($"Detecting global.json SDK version: {sdkVersion}");
+                    Log.Info($"Detecting global.json SDK version: {sdkVersion}");
                 }
             }
             else
@@ -3622,7 +3637,7 @@ namespace Microsoft.Crank.Agent
                 if (!File.Exists(globalJsonFilename))
                 {
                     // No global.json found
-                    Log.WriteLine($"Creating custom global.json");
+                    Log.Info($"Creating custom global.json");
 
                     var globalJson = "{ \"sdk\": { \"version\": \"" + sdkVersion + "\" } }";
                     File.WriteAllText(Path.Combine(benchmarkedApp, "global.json"), globalJson);
@@ -3630,7 +3645,7 @@ namespace Microsoft.Crank.Agent
                 else
                 {
                     // File found, we need to update it
-                    Log.WriteLine($"Patching existing global.json file");
+                    Log.Info($"Patching existing global.json file");
 
                     var globalObject = JObject.Parse(File.ReadAllText(globalJsonFilename));
 
@@ -3805,12 +3820,12 @@ namespace Microsoft.Crank.Agent
 
             if (!File.Exists(runtimeConfigFilename))
             {
-                Log.WriteLine("Ignoring runtimeconfig.json. File not found.");
+                Log.Info("Ignoring runtimeconfig.json. File not found.");
                 return;
             }
 
             // File found, we need to update it
-            Log.WriteLine($"Patching {Path.GetFileName(runtimeConfigFilename)} ");
+            Log.Info($"Patching {Path.GetFileName(runtimeConfigFilename)} ");
 
             var runtimeObject = JObject.Parse(File.ReadAllText(runtimeConfigFilename));
 
@@ -3818,7 +3833,7 @@ namespace Microsoft.Crank.Agent
 
             if (runtimeOptions.ContainsKey("includedFrameworks"))
             {
-                Log.WriteLine("Application is self-contained, skipping runtimeconfig.json");
+                Log.Info("Application is self-contained, skipping runtimeconfig.json");
                 return;
             }
 
@@ -3848,21 +3863,21 @@ namespace Microsoft.Crank.Agent
             if (String.Equals(sdkVersion, "Current", StringComparison.OrdinalIgnoreCase))
             {
                 sdkVersion = currentSdkVersion;
-                Log.WriteLine($"SDK: {sdkVersion} (Current)");
+                Log.Info($"SDK: {sdkVersion} (Current)");
             }
             else if (String.Equals(sdkVersion, "Latest", StringComparison.OrdinalIgnoreCase))
             {
                 sdkVersion = await GetAspNetSdkVersion();
-                Log.WriteLine($"SDK: {sdkVersion} (Latest)");
+                Log.Info($"SDK: {sdkVersion} (Latest)");
             }
             else if (String.Equals(sdkVersion, "Edge", StringComparison.OrdinalIgnoreCase))
             {
                 (sdkVersion, _) = await ParseLatestVersionFile(_latestSdkVersionUrl);
-                Log.WriteLine($"SDK: {sdkVersion} (Edge)");
+                Log.Info($"SDK: {sdkVersion} (Edge)");
             }
             else
             {
-                Log.WriteLine($"SDK: {sdkVersion} (Specific)");
+                Log.Info($"SDK: {sdkVersion} (Specific)");
             }
 
             return sdkVersion;
@@ -3873,14 +3888,14 @@ namespace Microsoft.Crank.Agent
             if (String.Equals(runtimeVersion, "Current", StringComparison.OrdinalIgnoreCase))
             {
                 runtimeVersion = currentRuntimeVersion;
-                Log.WriteLine($"Runtime: {runtimeVersion} (Current)");
+                Log.Info($"Runtime: {runtimeVersion} (Current)");
             }
             else if (String.Equals(runtimeVersion, "Latest", StringComparison.OrdinalIgnoreCase))
             {
                 // Get the version that is defined by the ASP.NET repository
                 // Note: to use the latest build available, use Edge channel
                 runtimeVersion = await GetAspNetRuntimeVersion(buildToolsPath, targetFramework);
-                Log.WriteLine($"Runtime: {runtimeVersion} (Latest)");
+                Log.Info($"Runtime: {runtimeVersion} (Latest)");
             }
             else if (String.Equals(runtimeVersion, "Edge", StringComparison.OrdinalIgnoreCase))
             {
@@ -3896,7 +3911,7 @@ namespace Microsoft.Crank.Agent
 
                         if (!String.IsNullOrEmpty(runtimeVersion))
                         {
-                            Log.WriteLine($"Runtime: {runtimeVersion} (Edge)");
+                            Log.Info($"Runtime: {runtimeVersion} (Edge)");
                             break;
                         }
                     }
@@ -3908,7 +3923,7 @@ namespace Microsoft.Crank.Agent
             else
             {
                 // Custom version
-                Log.WriteLine($"Runtime: {runtimeVersion} (Specific)");
+                Log.Info($"Runtime: {runtimeVersion} (Specific)");
             }
 
             return runtimeVersion;
@@ -3919,23 +3934,23 @@ namespace Microsoft.Crank.Agent
             if (String.Equals(desktopVersion, "Current", StringComparison.OrdinalIgnoreCase))
             {
                 desktopVersion = currentDesktopVersion;
-                Log.WriteLine($"Desktop: {desktopVersion} (Current)");
+                Log.Info($"Desktop: {desktopVersion} (Current)");
             }
             else if (String.Equals(desktopVersion, "Latest", StringComparison.OrdinalIgnoreCase))
             {
                 desktopVersion = currentDesktopVersion;
-                Log.WriteLine($"Desktop: {currentDesktopVersion} (Latest)");
+                Log.Info($"Desktop: {currentDesktopVersion} (Latest)");
             }
             else if (String.Equals(desktopVersion, "Edge", StringComparison.OrdinalIgnoreCase))
             {
                 desktopVersion = currentDesktopVersion;
-                Log.WriteLine($"Desktop: {currentDesktopVersion} (Edge)");
+                Log.Info($"Desktop: {currentDesktopVersion} (Edge)");
             }
             else
             {
                 // Custom version
                 desktopVersion = currentDesktopVersion;
-                Log.WriteLine($"Desktop: {desktopVersion} (Current)");
+                Log.Info($"Desktop: {desktopVersion} (Current)");
             }
 
             return desktopVersion;
@@ -4044,7 +4059,7 @@ namespace Microsoft.Crank.Agent
                     break;
             }
 
-            Log.WriteLine($"Detecting AspNetCore repository runtime version: {latestRuntimeVersion}");
+            Log.Info($"Detecting AspNetCore repository runtime version: {latestRuntimeVersion}");
             return latestRuntimeVersion;
         }
 
@@ -4077,7 +4092,7 @@ namespace Microsoft.Crank.Agent
             }
             catch
             {
-                Log.WriteLine("Could not load release metadata file for current versions");
+                Log.Info("Could not load release metadata file for current versions");
 
                 return (null, null, null, null);
             }
@@ -4104,7 +4119,7 @@ namespace Microsoft.Crank.Agent
 
         private static async Task<bool> DownloadFileAsync(string url, string outputPath, int maxRetries, int timeout = 5, bool throwOnError = true)
         {
-            Log.WriteLine($"Downloading {url}");
+            Log.Info($"Downloading {url}");
 
             HttpResponseMessage response = null;
 
@@ -4128,7 +4143,7 @@ namespace Microsoft.Crank.Agent
                 }
                 catch (OperationCanceledException)
                 {
-                    Log.WriteLine($"Timeout trying to download {url}, attempt {i + 1}");
+                    Log.Info($"Timeout trying to download {url}, attempt {i + 1}");
                 }
                 catch (HttpRequestException)
                 {
@@ -4140,7 +4155,7 @@ namespace Microsoft.Crank.Agent
                 }
                 catch (Exception ex)
                 {
-                    Log.WriteLine($"Failed to download {url}, attempt {i + 1}, Exception: {ex}");
+                    Log.Info($"Failed to download {url}, attempt {i + 1}, Exception: {ex}");
                 }
             }
 
@@ -4164,7 +4179,7 @@ namespace Microsoft.Crank.Agent
             else
             {
                 Directory.CreateDirectory(temp);
-                Log.WriteLine($"Created temp directory '{temp}'");
+                Log.Info($"Created temp directory '{temp}'");
                 return temp;
             }
         }
@@ -4182,7 +4197,7 @@ namespace Microsoft.Crank.Agent
             }
             catch
             {
-                Log.WriteLine($"[ERROR] Could not delete file '{path}'");
+                Log.Error($"[ERROR] Could not delete file '{path}'");
             }
 
             return false;
@@ -4195,7 +4210,7 @@ namespace Microsoft.Crank.Agent
                 return;
             }
 
-            Log.WriteLine($"Deleting directory '{path}'");
+            Log.Info($"Deleting directory '{path}'");
 
             var retryDelays = new[] { 50, 100, 500, 1000 };
 
@@ -4216,12 +4231,12 @@ namespace Microsoft.Crank.Agent
                 }
                 catch (DirectoryNotFoundException)
                 {
-                    Log.WriteLine("Directory not found");
+                    Log.Info("Directory not found");
                     break;
                 }
                 catch
                 {
-                    Log.WriteLine("Error, retrying ...");
+                    Log.Info("Error, retrying ...");
 
                     await Task.Delay(delay);
                 }
@@ -4229,7 +4244,7 @@ namespace Microsoft.Crank.Agent
 
             if (!success)
             {
-                Log.WriteLine($"[ERROR] Failed to delete directory '{path}'");
+                Log.Error($"[ERROR] Failed to delete directory '{path}'");
             }
         }
 
@@ -4310,7 +4325,7 @@ namespace Microsoft.Crank.Agent
 
             if (iis)
             {
-                Log.WriteLine($"Generating application host config for '{executable} {commandLine}'");
+                Log.Info($"Generating application host config for '{executable} {commandLine}'");
 
                 var apphost = GenerateApplicationHostConfig(job, job.BasePath, executable, commandLine, hostname);
                 commandLine = $"-h \"{apphost}\"";
@@ -4379,9 +4394,9 @@ namespace Microsoft.Crank.Agent
                 executable = "cgexec";
             }
 
-            Log.WriteLine($"Invoking executable: {executable}");
-            Log.WriteLine($"  Arguments: {commandLine}");
-            Log.WriteLine($"  Working directory: {workingDirectory}");
+            Log.Info($"Invoking executable: {executable}");
+            Log.Info($"  Arguments: {commandLine}");
+            Log.Info($"  Working directory: {workingDirectory}");
 
             var process = new Process()
             {
@@ -4415,7 +4430,7 @@ namespace Microsoft.Crank.Agent
 
             foreach (var env in job.EnvironmentVariables)
             {
-                Log.WriteLine($"Setting ENV: {env.Key} = {env.Value}");
+                Log.Info($"Setting ENV: {env.Key} = {env.Value}");
                 process.StartInfo.Environment.Add(env.Key, env.Value);
             }
 
@@ -4425,13 +4440,13 @@ namespace Microsoft.Crank.Agent
             {
                 if (e != null && e.Data != null)
                 {
-                    Log.WriteLine(e.Data);
+                    Log.Info(e.Data);
 
                     job.Output.AddLine(e.Data);
 
                     if (job.State == JobState.Starting && !String.IsNullOrEmpty(job.ReadyStateText) && e.Data.IndexOf(job.ReadyStateText, StringComparison.OrdinalIgnoreCase) >= 0)
                     {
-                        Log.WriteLine($"Ready state detected, application is now running...");
+                        Log.Info($"Ready state detected, application is now running...");
                         RunAndTrace();
                     }
 
@@ -4445,13 +4460,13 @@ namespace Microsoft.Crank.Agent
                 {
                     var log = "[STDERR] " + e.Data;
 
-                    Log.WriteLine(log);
+                    Log.Info(log);
 
                     job.Output.AddLine(log);
 
                     if (job.State == JobState.Starting && !String.IsNullOrEmpty(job.ReadyStateText) && e.Data.IndexOf(job.ReadyStateText, StringComparison.OrdinalIgnoreCase) >= 0)
                     {
-                        Log.WriteLine($"Ready state detected, application is now running...");
+                        Log.Info($"Ready state detected, application is now running...");
                         RunAndTrace();
                     }
 
@@ -4460,7 +4475,7 @@ namespace Microsoft.Crank.Agent
                     if (e.Data.StartsWith(processIdMarker) 
                         && int.TryParse(e.Data.Substring(processIdMarker.Length), out var childProcessId))
                     {
-                        Log.WriteLine($"Tracking child process id: {childProcessId}");
+                        Log.Info($"Tracking child process id: {childProcessId}");
                         job.ChildProcessId = childProcessId;
                     }
                 }
@@ -4506,7 +4521,7 @@ namespace Microsoft.Crank.Agent
 
                 if (job.MemoryLimitInBytes > 0)
                 {
-                    Log.WriteLine($"Creating Job Object with memory limits: {job.MemoryLimitInBytes / 1024 / 1024:n0} MB");
+                    Log.Info($"Creating Job Object with memory limits: {job.MemoryLimitInBytes / 1024 / 1024:n0} MB");
 
                     var hJob = Kernel32.CreateJobObject(null, job.RunId);
                     var bi = Kernel32.QueryInformationJobObject<Kernel32.JOBOBJECT_EXTENDED_LIMIT_INFORMATION>(hJob, Kernel32.JOBOBJECTINFOCLASS.JobObjectExtendedLimitInformation);
@@ -4518,7 +4533,7 @@ namespace Microsoft.Crank.Agent
 
                     process.Exited += (sender, e) =>
                     {
-                        Log.WriteLine("Releasing job object");
+                        Log.Info("Releasing job object");
                         Kernel32.TerminateJobObject(hJob, 0);
                         safeProcess.Dispose();
                     };
@@ -4549,7 +4564,7 @@ namespace Microsoft.Crank.Agent
                     var ssi = Kernel32.GetSystemCpuSetInformation(safeProcess).ToArray();
                     var cpuSets = cpuSet.Select(i => ssi[i].CpuSet.Id).ToArray();
 
-                    Log.WriteLine($"Limiting CpuSet ids: {String.Join(',', cpuSets)}");
+                    Log.Info($"Limiting CpuSet ids: {String.Join(',', cpuSets)}");
 
                     var result = Kernel32.SetProcessDefaultCpuSets(safeProcess, cpuSets, (uint)cpuSets.Length);
                 }              
@@ -4603,7 +4618,7 @@ namespace Microsoft.Crank.Agent
                 throw new ArgumentException($"Undefined process id for '{job.Service}'");
             }
 
-            Log.WriteLine("Starting counters");
+            Log.Info("Starting counters");
 
             var client = new DiagnosticsClient(job.ProcessId);
 
@@ -4639,28 +4654,28 @@ namespace Microsoft.Crank.Agent
 
                 try
                 {
-                    Log.WriteLine("Starting event pipe session");
+                    Log.Info("Starting event pipe session");
                     context.EventPipeSession = client.StartEventPipeSession(providerList, requestRundown: false);
                     break;
                 }
                 catch (ServerNotAvailableException)
                 {
-                    Log.WriteLine("IPC endpoint not available, retrying...");
+                    Log.Error("IPC endpoint not available, retrying...");
                     await Task.Delay(retryDelay);
                 }
                 catch (EndOfStreamException)
                 {
-                    Log.WriteLine($"[ERROR] Application stopped before an event pipe session could be created ({job.Service}:{job.Id})");
+                    Log.Error($"[ERROR] Application stopped before an event pipe session could be created ({job.Service}:{job.Id})");
                     return;
                 }
                 catch (TimeoutException)
                 {
-                    Log.WriteLine($"[ERROR] Event pipe session creation timed out. Application might be stopped ({job.Service}:{job.Id})");
+                    Log.Error($"[ERROR] Event pipe session creation timed out. Application might be stopped ({job.Service}:{job.Id})");
                     return;
                 }
                 catch (Exception e)
                 {
-                    Log.WriteLine("[ERROR] DiagnosticsClient.StartEventPipeSession() -> " + e.ToString());
+                    Log.Error("[ERROR] DiagnosticsClient.StartEventPipeSession() -> " + e.ToString());
 
                     if (job.State == JobState.Deleting
                         || job.State == JobState.Deleted
@@ -4679,22 +4694,22 @@ namespace Microsoft.Crank.Agent
 
             if (retries >= maxAttempts)
             {
-                Log.WriteLine($"[WARNING] Failed to create event pipe client after {maxAttempts} attempts. Counters will be ignored.");
+                Log.Warning($"[WARNING] Failed to create event pipe client after {maxAttempts} attempts. Counters will be ignored.");
                 return;
             }
 
             context.CountersCompletionSource = new TaskCompletionSource<bool>();
 
-            Log.WriteLine("Event pipe session started");
+            Log.Info("Event pipe session started");
 
             // Run asynchronously so it doesn't block the agent
             var streamTask = Task.Run(() =>
             {
                 var source = new EventPipeEventSource(context.EventPipeSession.EventStream);
 
-                Log.WriteLine("Event pipe source created");
+                Log.Info("Event pipe source created");
 
-                source.Dynamic.All += (TraceEvent eventData) => 
+                source.Dynamic.All += (TraceEvent eventData) =>
                 {
                     // We only track event counters for System.Runtime
                     if (eventData.ProviderName == "Benchmarks")
@@ -4762,7 +4777,7 @@ namespace Microsoft.Crank.Agent
                                 measurement.Value = payloadFields["Mean"];
                                 break;
                             default:
-                                Log.WriteLine($"Unknown CounterType: {payloadFields["CounterType"]}");
+                                Log.Info($"Unknown CounterType: {payloadFields["CounterType"]}");
                                 break;
                         }
 
@@ -4774,9 +4789,9 @@ namespace Microsoft.Crank.Agent
 
                 try
                 {
-                    Log.WriteLine($"Processing event pipe source ({job.Service}:{job.Id})...");
+                    Log.Info($"Processing event pipe source ({job.Service}:{job.Id})...");
                     source.Process();
-                    Log.WriteLine($"Event pipe source stopped ({job.Service}:{job.Id})");
+                    Log.Info($"Event pipe source stopped ({job.Service}:{job.Id})");
                 }
                 catch (Exception e)
                 {
@@ -4784,31 +4799,31 @@ namespace Microsoft.Crank.Agent
                     {
                         // Expected if the process has exited by itself
                         // and the event pipe is till trying to read from it
-                        Log.WriteLine($"[WARNING] Event pipe reading an exited process");
+                        Log.Warning($"[WARNING] Event pipe reading an exited process");
                     }
                     else
                     {
-                        Log.WriteLine($"[ERROR] source.Process() -> {e.ToString()}");
+                        Log.Error(e, "[ERROR] source.Process()");
                     }
                 }
             });
 
             var stopTask = Task.Run(async () =>
             {
-                Log.WriteLine($"Waiting for event pipe session to stop ({job.Service}:{job.Id})...");
+                Log.Info($"Waiting for event pipe session to stop ({job.Service}:{job.Id})...");
 
                 await Task.WhenAny(streamTask, context.CountersCompletionSource.Task);
 
-                Log.WriteLine($"Stopping event pipe session ({job.Service}:{job.Id})...");
-                
+                Log.Info($"Stopping event pipe session ({job.Service}:{job.Id})...");
+
                 if (streamTask.IsCompleted)
                 {
-                    Log.WriteLine($"Reason: event pipe source has ended");
+                    Log.Info($"Reason: event pipe source has ended");
                 }
 
                 if (context.CountersCompletionSource.Task.IsCompleted)
                 {
-                    Log.WriteLine($"Reason: counters are being stopped");
+                    Log.Info($"Reason: counters are being stopped");
                 }
 
                 try
@@ -4816,15 +4831,15 @@ namespace Microsoft.Crank.Agent
                     // It also interrupts the source.Process() blocking operation
                     await context.EventPipeSession.StopAsync(default);
 
-                    Log.WriteLine($"Event pipe session stopped ({job.Service}:{job.Id})");
+                    Log.Info($"Event pipe session stopped ({job.Service}:{job.Id})");
                 }
                 catch (ServerNotAvailableException)
                 {
-                    Log.WriteLine($"Event pipe session interupted, application has already exited ({job.Service}:{job.Id})");
+                    Log.Info($"Event pipe session interupted, application has already exited ({job.Service}:{job.Id})");
                 }
                 catch (Exception e)
                 {
-                    Log.WriteLine($"Event pipe session failed stopping ({job.Service}:{job.Id}): {e}");
+                    Log.Info($"Event pipe session failed stopping ({job.Service}:{job.Id}): {e}");
                 }
                 finally
                 {
@@ -4841,7 +4856,7 @@ namespace Microsoft.Crank.Agent
             context.EventPipeSession.Dispose();
             context.EventPipeSession = null;
 
-            Log.WriteLine($"Event pipes terminated ({job.Service}:{job.Id})");
+            Log.Info($"Event pipes terminated ({job.Service}:{job.Id})");
         }
 
         private static void StartCollection(string workingDirectory, Job job)
@@ -4869,8 +4884,8 @@ namespace Microsoft.Crank.Agent
                 }
 
                 RunPerfview($"start /AcceptEula /NoGui {_startPerfviewArguments} \"{job.PerfViewTraceFile}\"", workingDirectory);
-                Log.WriteLine($"Starting PerfView {_startPerfviewArguments}");
-                
+                Log.Info($"Starting PerfView {_startPerfviewArguments}");
+
                 // PerfView adds ".etl.zip" to the requested filename
                 job.PerfViewTraceFile = job.PerfViewTraceFile + ".etl.zip";
             }
@@ -4944,7 +4959,7 @@ namespace Microsoft.Crank.Agent
 
                 if (!File.Exists(runtimePath))
                 {
-                    Log.WriteLine($"Downloading mono runtime package");
+                    Log.Info($"Downloading mono runtime package");
 
                     var found = false;
                     foreach (var feed in _runtimeFeedUrls)
@@ -4969,7 +4984,7 @@ namespace Microsoft.Crank.Agent
                 }
                 else
                 {
-                    Log.WriteLine($"Found mono runtime package at '{runtimePath}'");
+                    Log.Info($"Found mono runtime package at '{runtimePath}'");
                 }
 
                 using (var archive = ZipFile.OpenRead(runtimePath))
@@ -4983,7 +4998,7 @@ namespace Microsoft.Crank.Agent
             }
             catch (Exception e)
             {
-                Log.WriteLine("ERROR: Failed to download mono runtime. " + e.ToString());
+                Log.Error(e, "ERROR: Failed to download mono runtime. ");
                 throw;
             }
         }
@@ -5009,7 +5024,7 @@ namespace Microsoft.Crank.Agent
                 {
                     Directory.CreateDirectory(Path.GetDirectoryName(dotnetMonoPath));
 
-                    Log.WriteLine($"Downloading dotnet skd package for mono AOT");
+                    Log.Info($"Downloading dotnet skd package for mono AOT");
 
                     var found = false;
                     var url = $"https://dotnetcli.azureedge.net/dotnet/Sdk/{dotnetSdkVersion}/dotnet-sdk-{dotnetSdkVersion}-linux-{pkgNameSuffix}.tar.gz";
@@ -5026,13 +5041,13 @@ namespace Microsoft.Crank.Agent
                     else
                     {
                         var strCmdTar = $"tar -xf dotnet-sdk-{dotnetSdkVersion}-linux-{pkgNameSuffix}.tar.gz";
-                        var resultTar = await ProcessUtil.RunAsync(fileName, 
+                        var resultTar = await ProcessUtil.RunAsync(fileName,
                             ConvertCmd2Arg(strCmdTar),
                             workingDirectory: Path.GetDirectoryName(dotnetMonoPath),
                             log: true);
                     }
 
-                    Log.WriteLine($"Patching local dotnet with mono runtime and extracting llvm");
+                    Log.Info($"Patching local dotnet with mono runtime and extracting llvm");
 
                     if (Directory.Exists(llvmExtractDir))
                     {
@@ -5058,7 +5073,7 @@ namespace Microsoft.Crank.Agent
                 }
                 else
                 {
-                    Log.WriteLine($"Found local dotnet with mono runtime at '{Path.GetDirectoryName(dotnetMonoPath)}'");
+                    Log.Info($"Found local dotnet with mono runtime at '{Path.GetDirectoryName(dotnetMonoPath)}'");
                 }
 
                 // Copy over mono runtime
@@ -5074,7 +5089,7 @@ namespace Microsoft.Crank.Agent
                 File.Copy(Path.Combine(outputFolder, "System.Private.CoreLib.dll"), Path.Combine(Path.GetDirectoryName(dotnetMonoPath), "shared", "Microsoft.NETCore.App", MicrosoftNETCoreAppPackageVersion, "System.Private.CoreLib.dll"), true);
                 File.Copy(Path.Combine(outputFolder, "libcoreclr.so"), Path.Combine(Path.GetDirectoryName(dotnetMonoPath), "shared", "Microsoft.NETCore.App", MicrosoftNETCoreAppPackageVersion, "libcoreclr.so"), true);
 
-                Log.WriteLine("Pre-compile assemblies inside publish folder");
+                Log.Info("Pre-compile assemblies inside publish folder");
 
                 var strCmdPreCompile = $@"for assembly in {outputFolder}/*.dll; do
                                               PATH={llvmExtractDir}:${{PATH}} MONO_ENV_OPTIONS=--aot=llvm,mcpu=native ./dotnet $assembly;
@@ -5086,7 +5101,7 @@ namespace Microsoft.Crank.Agent
             }
             catch (Exception e)
             {
-                Log.WriteLine("ERROR: Failed to AOT for mono. " + e.ToString());
+                Log.Error(e, "ERROR: Failed to AOT for mono.");
                 throw;
             }
         }
@@ -5115,11 +5130,11 @@ namespace Microsoft.Crank.Agent
                 Value = stopwatch.ElapsedMilliseconds
             });
 
-            Log.WriteLine($"Running job '{job.Service}' ({job.Id})");
+            Log.Info($"Running job '{job.Service}' ({job.Id})");
             job.Url = ComputeServerUrl(hostname, job);
 
             // Mark the job as running to allow the Client to start the test
-            Log.WriteLine($"{job.State} -> Running ({job.Service}:{job.Id})");
+            Log.Info($"{job.State} -> Running ({job.Service}:{job.Id})");
             job.State = JobState.Running;
 
             return true;
@@ -5265,8 +5280,7 @@ namespace Microsoft.Crank.Agent
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine($"Error while downloading {url}:");
-                    Console.WriteLine(e);
+                    Logger.Error(e, $"Error while downloading {url}:");
                 }
             }
 
@@ -5275,7 +5289,7 @@ namespace Microsoft.Crank.Agent
 
         private static async Task<string> GetLatestPackageVersion(string packageIndexUrl, string versionPrefix)
         {
-            Log.WriteLine($"Downloading package metadata ...");
+            Log.Info($"Downloading package metadata ...");
             var index = JObject.Parse(await DownloadContentAsync(packageIndexUrl));
 
             var compatiblePages = index["items"].Where(t => ((string)t["lower"]).StartsWith(versionPrefix)).ToArray();
@@ -5347,7 +5361,7 @@ namespace Microsoft.Crank.Agent
 
             var download_link = String.Format(urlPattern, version, GetPlatformMoniker(), extension, dotnetFeed);
 
-            Log.WriteLine($"Checking package: {download_link}");
+            Log.Info($"Checking package: {download_link}");
 
             var httpMessage = new HttpRequestMessage(HttpMethod.Head, download_link);
             httpMessage.Headers.IfModifiedSince = DateTime.Now;
@@ -5394,7 +5408,7 @@ namespace Microsoft.Crank.Agent
                 }
                 else
                 {
-                    Log.WriteLine($"Package not available: {runtimeType} version {version}");
+                    Log.Info($"Package not available: {runtimeType} version {version}");
                 }
             }
 
@@ -5476,7 +5490,7 @@ namespace Microsoft.Crank.Agent
                 providers = "cpu-sampling";
             }
 
-            var providerArguments = providers.Split(new [] { ',', ' '}, StringSplitOptions.RemoveEmptyEntries);
+            var providerArguments = providers.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
 
             IEnumerable<EventPipeProvider> providerCollection = new List<EventPipeProvider>();
 
@@ -5485,7 +5499,7 @@ namespace Microsoft.Crank.Agent
                 // Is it a profile (cpu-sampling, ...)?
                 if (TraceExtensions.DotNETRuntimeProfiles.TryGetValue(providerArgument, out var profile))
                 {
-                    Log.WriteLine($"Adding dotnet-trace profiles: {providerArgument}");
+                    Log.Info($"Adding dotnet-trace profiles: {providerArgument}");
                     providerCollection = TraceExtensions.Merge(providerCollection, profile);
                 }
                 else
@@ -5494,7 +5508,7 @@ namespace Microsoft.Crank.Agent
                     var clrEvents = TraceExtensions.ToCLREventPipeProviders(providerArgument);
                     if (clrEvents.Any())
                     {
-                        Log.WriteLine($"Adding dotnet-trace clrEvents: {providerArgument}");
+                        Log.Info($"Adding dotnet-trace clrEvents: {providerArgument}");
                         providerCollection = TraceExtensions.Merge(providerCollection, clrEvents);
                     }
                     else
@@ -5503,7 +5517,7 @@ namespace Microsoft.Crank.Agent
                         var knownProvider = TraceExtensions.ToProvider(providerArgument);
                         if (knownProvider.Any())
                         {
-                            Log.WriteLine($"Adding dotnet-trace provider: {providerArgument}");
+                            Log.Info($"Adding dotnet-trace provider: {providerArgument}");
                             providerCollection = TraceExtensions.Merge(providerCollection, knownProvider);
                         }
                     }
@@ -5513,18 +5527,18 @@ namespace Microsoft.Crank.Agent
 
             if (!providerCollection.Any())
             {
-                Log.WriteLine($"Tracing arguments not valid: {providers}");
+                Log.Info($"Tracing arguments not valid: {providers}");
 
                 return -1;
             }
             else
             {
-                Log.WriteLine($"dotnet-trace providers: ");
+                Log.Info($"dotnet-trace providers: ");
 
 
                 foreach (var provider in providerCollection)
                 {
-                    Log.WriteLine(provider.ToString());
+                    Log.Info(provider.ToString());
                 }
             }
 
@@ -5533,7 +5547,7 @@ namespace Microsoft.Crank.Agent
             var client = new DiagnosticsClient(processId);
             EventPipeSession traceSession = client.StartEventPipeSession(providerCollection, circularBufferMB: buffersize);
 
-            var collectingTask = new Task(async () => 
+            var collectingTask = new Task(async () =>
             {
                 try
                 {
@@ -5542,11 +5556,11 @@ namespace Microsoft.Crank.Agent
                         await traceSession.EventStream.CopyToAsync(fs);
                     }
 
-                    Log.WriteLine($"Tracing session ended.");
+                    Log.Info($"Tracing session ended.");
                 }
                 catch (Exception ex)
                 {
-                    Log.WriteLine($"Tracing failed with exception {ex}");
+                    Log.Info($"Tracing failed with exception {ex}");
                     failed = true;
                 }
                 finally
@@ -5567,7 +5581,7 @@ namespace Microsoft.Crank.Agent
             traceSession.Stop();
             traceSession.Dispose();
 
-            Log.WriteLine($"Tracing finalized");
+            Log.Info($"Tracing finalized");
 
             return failed ? -1 : 0;
         }
@@ -5597,7 +5611,7 @@ namespace Microsoft.Crank.Agent
 
         public static async Task EnsureDotnetInstallExistsAsync()
         {
-            Log.WriteLine($"Checking requirements...");
+            Log.Info($"Checking requirements...");
 
             // Add a NuGet.config for the self-contained deployments to be able to find the runtime packages on the CI feeds
             // This is not taken into account however if the source folder contains its own with a <clear /> statement as this one
@@ -5642,7 +5656,7 @@ namespace Microsoft.Crank.Agent
 
                 if (!File.Exists(_perfviewPath))
                 {
-                    Log.WriteLine($"Downloading PerfView to '{_perfviewPath}'");
+                    Log.Info($"Downloading PerfView to '{_perfviewPath}'");
                     await DownloadFileAsync(_perfviewUrl, _perfviewPath, maxRetries: 5, timeout: 60);
                 }
             }
@@ -5665,7 +5679,7 @@ namespace Microsoft.Crank.Agent
 
             if (!File.Exists(dotnetInstallFilename))
             {
-                Log.WriteLine($"Downloading dotnet-install to '{dotnetInstallFilename}'");
+                Log.Info($"Downloading dotnet-install to '{dotnetInstallFilename}'");
                 await DownloadFileAsync(_dotnetInstallUrl, dotnetInstallFilename, maxRetries: 5, timeout: 60);
             }
         }
@@ -5674,7 +5688,7 @@ namespace Microsoft.Crank.Agent
         {
             try
             {
-                Log.WriteLine("Cancelling remaining jobs");
+                Log.Info("Cancelling remaining jobs");
 
                 if (!_processJobsCts.IsCancellationRequested)
                 {
@@ -5683,7 +5697,7 @@ namespace Microsoft.Crank.Agent
                     Task.WaitAny(_processJobsTask, Task.Delay(TimeSpan.FromSeconds(30)));
                 }
 
-                Log.WriteLine("Cleaning up temporary folder...");
+                Log.Info("Cleaning up temporary folder...");
 
                 // build servers will hold locks on dotnet.exe otherwise
                 // c.f. https://github.com/dotnet/sdk/issues/9487


### PR DESCRIPTION
As discussed in https://github.com/dotnet/crank/pull/365, this PR adds log file support for crank agent.
Users can pass an opt-in `--log-path` command-line argument with a full path to a log-file.

Log files roll every 1 day.