### PR TITLE
Execute scripts after results are available

### DIFF
--- a/src/Microsoft.Crank.Controller/Configuration.cs
+++ b/src/Microsoft.Crank.Controller/Configuration.cs
@@ -29,14 +29,20 @@ namespace Microsoft.Crank.Controller
         public List<string> DefaultScripts { get; set; } = new List<string>();
 
         /// <summary>
-        ///  List of named script sections that can be executed in a run
+        /// .NET counters that are available during a benchmark.
         /// </summary>
         public List<CounterList> Counters { get; set; } = new List<CounterList>();
 
         /// <summary>
-        ///  List of named script sections that can be executed in a run
+        /// Computed results definitions.
         /// </summary>
         public List<Result> Results { get; set; } = new List<Result>();
+
+        /// <summary>
+        /// Scripts to run when the results are computed.
+        /// </summary>
+        public List<string> OnResultsCreated { get; set; } = new List<string>();
+
     }
 
     public class Scenario

--- a/src/Microsoft.Crank.Models/JobResults.cs
+++ b/src/Microsoft.Crank.Models/JobResults.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Crank.Models
         public List<Measurement[]> Measurements { get; set; } = new List<Measurement[]>();
         public Dictionary<string, object> Environment { get; set; } = new Dictionary<string, object>();
     }
+
     public class ResultMetadata
     {
         public string Name { get; set; }


### PR DESCRIPTION
Example:

```yaml
results: # creates results from measurements

- name: runtime-counter/alloc-rate/p90
  measurement: runtime-counter/alloc-rate
  description: 90th Allocation Rate (B/sec)
  format: n0
  aggregate: percentile90
  reduce: sum

# register a custom result
- name: alloc-per-request
  description: Allocations Per request (B/req)
  format: n2

onResultsCreated:
  - |
    var allocations = benchmarks.jobs.application.results["runtime-counter/alloc-rate/p90"]
    var rps = benchmarks.jobs.load.results["http/rps/mean"];
    benchmarks.jobs.application.results["alloc-per-request"] = allocations / rps;

```