### PR TITLE
Add a timeout option for Bombardier, wrk and wrk2 jobs

### DIFF
--- a/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
+++ b/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
@@ -22,6 +22,7 @@ jobs:
       warmup: 15
       duration: 15
       requests: 0
+      timeout: 2
       rate: 0
       transport: fasthttp # | http1 | http2
       serverScheme: http
@@ -31,6 +32,6 @@ jobs:
       bodyFile: # path or url for a file to use as the body content
       verb: # GET when nothing is specified
       customHeaders: [ ] # list of headers with the format: '<name1>: <value1>', e.g. [ 'content-type: application/json' ]
-    arguments: "-c {{connections}} -w {{warmup}} -d {{duration}} -n {{requests}} --insecure -l {% if rate != 0 %} --rate {{ rate }} {% endif %} {% if transport %} --{{ transport}} {% endif %} {{headers[presetHeaders]}} {% for h in customHeaders %}{% assign s = h | split : ':' %}--header \"{{ s[0] }}: {{ s[1] | strip }}\" {% endfor %} {% if serverUri == blank or serverUri == empty %} {{serverScheme}}://{{serverAddress}}:{{serverPort}}{{path}} {% else %} {{serverUri}}:{{serverPort}}{{path}} {% endif %} {% if bodyFile != blank and bodyFile != empty %} -f {{bodyFile}} {% endif %}  {% if verb != blank and verb != empty %} -m {{verb}} {% endif %}"
+    arguments: "-c {{connections}} -w {{warmup}} -d {{duration}} -n {{requests}} -t {{timeout}}s --insecure -l {% if rate != 0 %} --rate {{ rate }} {% endif %} {% if transport %} --{{ transport}} {% endif %} {{headers[presetHeaders]}} {% for h in customHeaders %}{% assign s = h | split : ':' %}--header \"{{ s[0] }}: {{ s[1] | strip }}\" {% endfor %} {% if serverUri == blank or serverUri == empty %} {{serverScheme}}://{{serverAddress}}:{{serverPort}}{{path}} {% else %} {{serverUri}}:{{serverPort}}{{path}} {% endif %} {% if bodyFile != blank and bodyFile != empty %} -f {{bodyFile}} {% endif %}  {% if verb != blank and verb != empty %} -m {{verb}} {% endif %}"
     onConfigure: 
       # - job.timeout = Number(job.variables.duration) + Number(job.variables.warmup) + 10;

--- a/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
+++ b/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
@@ -20,6 +20,7 @@ jobs:
     variables:
       connections: 256  # total number of HTTP connections to keep open with each thread handling N = connections/threads
       duration: 15 # duration in seconds
+      timeout: # timeout in seconds (optional)
       warmup: 15 # warmup in seconds
       threads: 32 # total number of threads to use
       pipeline: 1
@@ -30,7 +31,7 @@ jobs:
       serverPort: 5000
       serverPath: /
       customHeaders: [ ] # list of headers with the format: '<name1>: <value1>', e.g. [ 'content-type: application/json' ]
-    arguments: "-c {{connections}} {% if serverUri == blank or serverUri == empty %} {{serverScheme}}://{{serverAddress}}:{{serverPort}}{{path}} {% else %} {{serverUri}}:{{serverPort}}{{path}} {% endif %} --latency -d {{duration}}s -w {{warmup}}s -t {{threads}} {{headers[presetHeaders]}} {% for h in customHeaders %}{% assign s = h | split : ':' %}--header \"{{ s[0] }}: {{ s[1] | strip }}\" {% endfor %} {% if pipeline > 1 %} -s scripts/pipeline.lua -- {{ pipeline }} {% elsif script != blank and script != empty %} -s {{script}} -- {{scriptArguments}} {% endif %}"
+    arguments: "-c {{connections}} {% if serverUri == blank or serverUri == empty %} {{serverScheme}}://{{serverAddress}}:{{serverPort}}{{path}} {% else %} {{serverUri}}:{{serverPort}}{{path}} {% endif %} --latency -d {{duration}}s -w {{warmup}}s {% if timeout != blank and timeout != empty %} --timeout {{timeout}}s {% endif %} -t {{threads}} {{headers[presetHeaders]}} {% for h in customHeaders %}{% assign s = h | split : ':' %}--header \"{{ s[0] }}: {{ s[1] | strip }}\" {% endfor %} {% if pipeline > 1 %} -s scripts/pipeline.lua -- {{ pipeline }} {% elsif script != blank and script != empty %} -s {{script}} -- {{scriptArguments}} {% endif %}"
     options:
       requiredOperatingSystem: linux
     onConfigure:

--- a/src/Microsoft.Crank.Jobs.Wrk2/wrk2.yml
+++ b/src/Microsoft.Crank.Jobs.Wrk2/wrk2.yml
@@ -21,6 +21,7 @@ jobs:
     variables:
       connections: 256
       duration: 15
+      timeout: # timeout in seconds (optional)
       warmup: 15
       threads: 32
       rate: 500
@@ -29,6 +30,6 @@ jobs:
       serverPort: 5000
       serverPath: /
       customHeaders: [ ] # list of headers with the format: '<name1>: <value1>', e.g. [ 'content-type: application/json' ]
-    arguments: "-c {{connections}} -d {{duration}}s -w {{warmup}}s -t {{threads}} {{headers[presetHeaders]}} {% for h in customHeaders %}{% assign s = h | split : ':' %}--header \"{{ s[0] }}: {{ s[1] | strip }}\" {% endfor %} -R {{rate}} -L {% if serverUri == blank or serverUri == empty %} {{serverScheme}}://{{serverAddress}}:{{serverPort}}{{path}} {% else %} {{serverUri}}:{{serverPort}}{{path}} {% endif %}"
+    arguments: "-c {{connections}} -d {{duration}}s -w {{warmup}}s {% if timeout != blank and timeout != empty %} --timeout {{timeout}}s {% endif %} -t {{threads}} {{headers[presetHeaders]}} {% for h in customHeaders %}{% assign s = h | split : ':' %}--header \"{{ s[0] }}: {{ s[1] | strip }}\" {% endfor %} -R {{rate}} -L {% if serverUri == blank or serverUri == empty %} {{serverScheme}}://{{serverAddress}}:{{serverPort}}{{path}} {% else %} {{serverUri}}:{{serverPort}}{{path}} {% endif %}"
     options:
       requiredOperatingSystem: linux


### PR DESCRIPTION
Fixes #356

As suggested in #356, this PR adds support for the `--timeout` option that Bombardier, wrk and wrk2 support out of the box. 

Bombardier has a default timeout of 2s (thus the default value of 2 in the YAML file), while wrk and wrk2 do not have a default value (thus the empty default values in their respective YAML files, the `--timeout` option is passed only when it is not empty with a Fluid conditional expression).

This has been tested with the `hello` example and it works well:

```
[04:55:19.277] > wrk -d 15s -c 256 http://localhost:5000/ --latency --timeout 2s -t 32
[04:55:19.326] Processing job 'load' (2) in state Running
[04:55:20.345] Processing job 'application' (1) in state Running
[04:55:21.371] Processing job 'load' (2) in state Running
[...]
[04:57:01.897] > wrk2  -d 15s -c 256 --timeout 2s -t 32 -R 500 -L http://localhost:5000/
[04:57:01.997] Event pipe source created
[04:57:01.997] Processing event pipe source (load:4)...
[04:57:02.301] Processing job 'load' (4) in state Running
[...]
[05:09:17.659] > bombardier  -d 15s -c 256 -t 2s --insecure -l --fasthttp http://localhost:5000/ --print r --format json
[05:09:17.740] Event pipe source created
[05:09:17.745] Processing event pipe source (load:4)...
[05:09:18.426] Processing job 'application' (3) in state Running
[05:09:19.431] Processing job 'load' (4) in state Running
[...]
```