### PR TITLE
[BUGFIX] Bombardier job: remove duplicate req3xx in the requests number sum

### DIFF
--- a/src/Microsoft.Crank.Jobs.Bombardier/Program.cs
+++ b/src/Microsoft.Crank.Jobs.Bombardier/Program.cs
@@ -234,7 +234,6 @@ namespace Microsoft.Crank.Jobs.Bombardier
                     document["result"]["req1xx"].Value<long>()
                     + document["result"]["req2xx"].Value<long>()
                     + document["result"]["req3xx"].Value<long>()
-                    + document["result"]["req3xx"].Value<long>()
                     + document["result"]["req4xx"].Value<long>()
                     + document["result"]["req5xx"].Value<long>()
                     + document["result"]["others"].Value<long>();


### PR DESCRIPTION
This PR fixes the calculation of the total request number, the number of 3xx requests was duplicated (see below)

https://github.com/dotnet/crank/blob/4484a3418314f991528ba6e2a8797f2d2396a1b0/src/Microsoft.Crank.Jobs.Bombardier/Program.cs#L233-L240

The bug is not present for Wrk and Wrk2 as the total number of requests is parsed from the standard output.