### PR TITLE
[BUGFIX] Critical: fix duplication of the `--table` option

### DIFF
--- a/src/Microsoft.Crank.Controller/Program.cs
+++ b/src/Microsoft.Crank.Controller/Program.cs
@@ -154,8 +154,6 @@ namespace Microsoft.Crank.Controller
             _sqlTableOption = app.Option("--table",
                 "Table name or environment variable name of the SQL table to store results in.", CommandOptionType.SingleValue);
             _relayConnectionStringOption = app.Option("--relay", "Connection string or environment variable name of the Azure Relay namespace used to access the Crank Agent endpoints. e.g., 'Endpoint=sb://mynamespace.servicebus.windows.net;...', 'MY_AZURE_RELAY_ENV'", CommandOptionType.SingleValue);
-            _sessionOption = app.Option("--table",
-                "Table name of the SQL Database to store results in", CommandOptionType.SingleValue);
             _sessionOption = app.Option("--session", "A logical identifier to group related jobs.", CommandOptionType.SingleValue);
             _descriptionOption = app.Option("--description", "A string describing the job.", CommandOptionType.SingleValue);
             _propertyOption = app.Option("-p|--property", "Some custom key/value that will be added to the results, .e.g. --property arch=arm --property os=linux", CommandOptionType.MultipleValue);


### PR DESCRIPTION
Since version `0.2.0-alpha.22071.1` of Microsoft.Crank.Controller on [NuGet](https://www.nuget.org/packages/Microsoft.Crank.Controller/0.2.0-alpha.22071.1), I experience an issue when using the `--table` option of `crank`:

```
Unhandled exception. System.InvalidOperationException: Multiple options with name "table" found. This is usually due to nested options.
   at McMaster.Extensions.CommandLineUtils.CommandLineProcessor.FindOption(String name, Func`2 by)
   at McMaster.Extensions.CommandLineUtils.CommandLineProcessor.ProcessOption(OptionArgument arg)
   at McMaster.Extensions.CommandLineUtils.CommandLineProcessor.ProcessNext()
   at McMaster.Extensions.CommandLineUtils.CommandLineProcessor.Process()
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.Parse(String[] args)
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.ExecuteAsync(String[] args, CancellationToken cancellationToken)
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.Execute(String[] args)
   at Microsoft.Crank.Controller.Program.Main(String[] args)
```

By looking at the history of `src/Microsoft.Crank.Controller/Program.cs`, this seems to have been introduced recently in commit https://github.com/dotnet/crank/commit/8212425ebde663639643198c1cf3df0d89273e40.
The definition of `_sessionOption` is duplicated and defines a second `--table` option, as below:

https://github.com/dotnet/crank/blob/58bf29851e92f69428685346153467bdb2d39973/src/Microsoft.Crank.Controller/Program.cs#L154-L159

This PR fixes this bug by removing the extra `_sessionOption` as it totally breaks Crank when trying to use the `--table` option.