### PR TITLE
Do not output "Agent ready" when it's not ready yet

### DIFF
--- a/test/Microsoft.Crank.IntegrationTests/AgentFixture.cs
+++ b/test/Microsoft.Crank.IntegrationTests/AgentFixture.cs
@@ -55,9 +55,9 @@ namespace Microsoft.Crank.IntegrationTests
             // Wait either for the message of the agent to stop
             await Task.WhenAny(agentReadyTcs.Task, _agent);
 
-            if (!agentReadyTcs.Task.IsCompleted)
+            if (_agent.IsCompleted)
             {
-                Assert.True(false, "Agent could not start");
+                Assert.True(false, $"Agent exited with exit code {_agent.Result.ExitCode}");
             }
 
             _output.AppendLine($"[AGT] Started agent");

--- a/test/Microsoft.Crank.IntegrationTests/AgentFixture.cs
+++ b/test/Microsoft.Crank.IntegrationTests/AgentFixture.cs
@@ -57,11 +57,16 @@ namespace Microsoft.Crank.IntegrationTests
 
             if (_agent.IsCompleted)
             {
-                Assert.True(false, $"Agent exited with exit code {_agent.Result.ExitCode}");
+                _output.AppendLine($"[AGT] Agent exited with exit code {_agent.Result.ExitCode}");
+            }
+            else
+            {
+                _output.AppendLine($"[AGT] Started agent");
             }
 
-            _output.AppendLine($"[AGT] Started agent");
         }
+
+        public bool IsReady() => _agent != null && !_agent.IsCompleted;
 
         public async Task DisposeAsync()
         {

--- a/test/Microsoft.Crank.IntegrationTests/CommonTests.cs
+++ b/test/Microsoft.Crank.IntegrationTests/CommonTests.cs
@@ -25,6 +25,14 @@ namespace Microsoft.Crank.IntegrationTests
             _crankDirectory = Path.GetDirectoryName(typeof(CommonTests).Assembly.Location).Replace("Microsoft.Crank.IntegrationTests", "Microsoft.Crank.Controller");
             _crankTestsDirectory = Path.GetDirectoryName(typeof(CommonTests).Assembly.Location);
             _output.WriteLine($"[TEST] Running tests in {_crankDirectory}");
+
+            // Check if the agent is started
+            if (!_agent.IsReady())
+            {
+                // Dispose() will not be called, flush the agent output now
+                _output.WriteLine(_agent.FlushOutput());
+                Assert.True(false, "Agent failed to start");
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Two fixes here:

1. The agent will output `Agent ready` even tough it may fail to start (fails to bind the port for example). Instead of calling `host.RunAsync()`, wait explicitely that `host.StartAsync()` was completed before starting the logic to process jobs
2. In test, when the agent failed to start there was no log displayed. Instead of throwing an error in `AgentFixture`, I check that the agent was started successfully in the test constructor, flushing the agent logs if necessary