### PR TITLE
Support GitHub Enterprise

### DIFF
--- a/src/Microsoft.Crank.PullRequestBot/BotOptions.cs
+++ b/src/Microsoft.Crank.PullRequestBot/BotOptions.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Crank.PullRequestBot
         public long InstallId { get; set; }
         public string Config { get; set; }
         public bool Debug { get; set; }
+        public Uri GitHubBaseUrl { get; set; }
 
         public void Validate()
         {

--- a/src/Microsoft.Crank.PullRequestBot/CredentialsHelper.cs
+++ b/src/Microsoft.Crank.PullRequestBot/CredentialsHelper.cs
@@ -94,9 +94,9 @@ namespace Microsoft.Crank.PullRequestBot
             return null;
         }
 
-        public static GitHubClient CreateClient(Credentials credentials)
+        public static GitHubClient CreateClient(Credentials credentials, Uri baseAddress = null)
         {
-            var githubClient = new GitHubClient(ClientHeader);
+            var githubClient = new GitHubClient(ClientHeader, baseAddress ?? GitHubClient.GitHubApiUrl);
             githubClient.Credentials = credentials;
 
             return githubClient;

--- a/src/Microsoft.Crank.PullRequestBot/Program.cs
+++ b/src/Microsoft.Crank.PullRequestBot/Program.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Crank.PullRequestBot
                     "The GitHub installation id."),
                 new Option<Uri>(
                     "--github-base-url",
-                    "The base URL GitHub if using GitHub Enterprise, e.g., https://github.local"),
+                    "The GitHub base URL if using GitHub Enterprise, e.g., https://github.local"),
                 new Option<string>(
                     "--config",
                     "The path to a configuration file.") { IsRequired = true }


### PR DESCRIPTION
Support the use of GitHub Enterprise instances via a new `--github-base-url` parameter, which configures the Octokit client to use a different base address for API calls.
