### PR TITLE
Support additional crank arguments in crank-pr

### DIFF
--- a/src/Microsoft.Crank.PullRequestBot/BotOptions.cs
+++ b/src/Microsoft.Crank.PullRequestBot/BotOptions.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Crank.PullRequestBot
         public string Config { get; set; }
         public bool Debug { get; set; }
         public Uri GitHubBaseUrl { get; set; }
+        public string Arguments { get; set; }
 
         public void Validate()
         {

--- a/src/Microsoft.Crank.PullRequestBot/Program.cs
+++ b/src/Microsoft.Crank.PullRequestBot/Program.cs
@@ -104,6 +104,9 @@ namespace Microsoft.Crank.PullRequestBot
                     "--github-base-url",
                     "The GitHub base URL if using GitHub Enterprise, e.g., https://github.local"),
                 new Option<string>(
+                    "--arguments",
+                    "Any additional arguments to pass through to crank."),
+                new Option<string>(
                     "--config",
                     "The path to a configuration file.") { IsRequired = true }
             };
@@ -604,7 +607,7 @@ namespace Microsoft.Crank.PullRequestBot
                     File.Delete(prResultsFilename);
 
                     Directory.SetCurrentDirectory(cloneFolder);
-                    RunCrank(_configuration.Defaults, benchmark.Arguments, profile.Arguments, buildArguments, $@"--json ""{baseResultsFilename}""");
+                    RunCrank(_configuration.Defaults, benchmark.Arguments, profile.Arguments, buildArguments, $@"--json ""{baseResultsFilename}""", _options.Arguments);
                 }
 
                 await ProcessUtil.RunAsync("git", $@"fetch origin pull/{prNumber}/head", workingDirectory: cloneFolder, log: true);
@@ -625,7 +628,7 @@ namespace Microsoft.Crank.PullRequestBot
                     var prResultsFilename = $"{workspace}{run.Benchmark}.{PrFilename}";
 
                     Directory.SetCurrentDirectory(cloneFolder);
-                    RunCrank(_configuration.Defaults, benchmark.Arguments, profile.Arguments, buildArguments, $@"--json ""{prResultsFilename}""");
+                    RunCrank(_configuration.Defaults, benchmark.Arguments, profile.Arguments, buildArguments, $@"--json ""{prResultsFilename}""", _options.Arguments);
 
                     // Compare benchmarks
                     var result = RunCrank($"compare", $"{baseResultsFilename}", $"{prResultsFilename}");

--- a/src/Microsoft.Crank.PullRequestBot/README.md
+++ b/src/Microsoft.Crank.PullRequestBot/README.md
@@ -24,6 +24,7 @@ Options:
   --app-id <app-id>                      The GitHub application id.
   --install-id <install-id>              The GitHub installation id.
   --github-base-url <github-base-url>    The GitHub base URL if using GitHub Enterprise, e.g., https://github.local
+  --arguments <first second third ...>   Any additional arguments to pass through to crank.
   --config <config> (REQUIRED)           The path to a configuration file.
   --version                              Show version information
   -?, -h, --help                         Show help and usage information


### PR DESCRIPTION
Add support for passing additional arguments to crank from crank-pr.

Resolves #411.
