### PR TITLE
Use a bigger buffer for downloads

### DIFF
--- a/src/Microsoft.Crank.Controller/WebUtils.cs
+++ b/src/Microsoft.Crank.Controller/WebUtils.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Crank.Controller
             Console.WriteLine();
         }
 
-        internal static async Task CopyToAsync(this Stream source, Stream destination, IProgress<long> progress, CancellationToken cancellationToken = default(CancellationToken), int bufferSize = 0x1000)
+        internal static async Task CopyToAsync(this Stream source, Stream destination, IProgress<long> progress, CancellationToken cancellationToken = default(CancellationToken), int bufferSize = 0x10000)
         {
             var buffer = new byte[bufferSize];
             int bytesRead;


### PR DESCRIPTION
- 4K is too small so use 64K instead

Future: We can also use 2 buffers to do a faster download. You can read with the second buffer while the first one is in use from the previous write.