### PR TITLE
Don't resolve configuration path if it's an url

### DIFF
--- a/src/Microsoft.Crank.Controller/Program.cs
+++ b/src/Microsoft.Crank.Controller/Program.cs
@@ -2060,10 +2060,12 @@ namespace Microsoft.Crank.Controller
             {
                 string configurationContent;
 
+                var isRemoteConfiguration = configurationFilenameOrUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase);
+
                 // Load the job definition from a url or locally
                 try
                 {
-                    if (configurationFilenameOrUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+                    if (isRemoteConfiguration)
                     {
                         configurationContent = await _httpClient.GetStringAsync(configurationFilenameOrUrl);
                     }
@@ -2074,7 +2076,8 @@ namespace Microsoft.Crank.Controller
                 }
                 catch
                 {
-                    throw new ControllerException($"Configuration '{Path.GetFullPath(configurationFilenameOrUrl)}' could not be loaded.");
+                    var path = isRemoteConfiguration ? configurationFilenameOrUrl : Path.GetFullPath(configurationFilenameOrUrl);
+                    throw new ControllerException($"Configuration '{path}' could not be loaded.");
                 }
 
                 localconfiguration = null;


### PR DESCRIPTION
Because of a network error, I had a run fail with the message:

```
Configuration '/mnt/c/git/dd-trace-dotnet/tracer/build/crank/https:/raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml' could not be loaded.
```
which is incredibly confusing, and had me waste a few minutes to understand why Crank was apparently trying to convert the URL into a path.

This PR fixes the logic to resolve the path in the error message only if it isn't an URL.
