### PR TITLE
Fix Regression.Change to be current - previous

### DIFF
--- a/src/Microsoft.Crank.RegressionBot/Program.cs
+++ b/src/Microsoft.Crank.RegressionBot/Program.cs
@@ -735,7 +735,7 @@ namespace Microsoft.Crank.RegressionBot
                             {
                                 PreviousResult = resultSet[i+2].Result,
                                 CurrentResult = resultSet[i+3].Result,
-                                Change = value3,
+                                Change = CurrentResult - PreviousResult,
                                 StandardDeviation = standardDeviation,
                                 Average = average
                             };

--- a/src/Microsoft.Crank.RegressionBot/Program.cs
+++ b/src/Microsoft.Crank.RegressionBot/Program.cs
@@ -728,17 +728,17 @@ namespace Microsoft.Crank.RegressionBot
                             default:
                                 break;
                         }
-
-                        var previousResult = resultSet[i+2].Result;
-                        var currentResult = resultSet[i+3].Result;
+                        
+                        var currentValue = values[i + 3];
+                        var previousValue = values[i + 2];
                         
                         if (hasRegressed)
                         {
                             var regression = new Regression 
                             {
-                                PreviousResult = previousResult,
-                                CurrentResult = currentResult,
-                                Change = currentResult - previousResult,
+                                PreviousResult = resultSet[i+2].Result,
+                                CurrentResult = resultSet[i+3].Result,
+                                Change = currentValue - previousValue,
                                 StandardDeviation = standardDeviation,
                                 Average = average
                             };
@@ -746,7 +746,7 @@ namespace Microsoft.Crank.RegressionBot
                             if (_options.Verbose)
                             {
                                 Console.ForegroundColor = ConsoleColor.Red;
-                                Console.WriteLine($"Regression detected: {values[i + 2]:n0} to {values[i + 3]:n0} for {regression.Identifier}");
+                                Console.WriteLine($"Regression detected: {previousValue:n0} to {currentValue:n0} for {regression.Identifier}");
                                 Console.ResetColor();
                             }
 

--- a/src/Microsoft.Crank.RegressionBot/Program.cs
+++ b/src/Microsoft.Crank.RegressionBot/Program.cs
@@ -729,13 +729,16 @@ namespace Microsoft.Crank.RegressionBot
                                 break;
                         }
 
+                        var previousResult = resultSet[i+2].Result;
+                        var currentResult = resultSet[i+3].Result;
+                        
                         if (hasRegressed)
                         {
                             var regression = new Regression 
                             {
-                                PreviousResult = resultSet[i+2].Result,
-                                CurrentResult = resultSet[i+3].Result,
-                                Change = CurrentResult - PreviousResult,
+                                PreviousResult = previousResult,
+                                CurrentResult = currentResult,
+                                Change = currentResult - previousResult,
                                 StandardDeviation = standardDeviation,
                                 Average = average
                             };


### PR DESCRIPTION
This changes `Change` to mean the delta between the current result and the one before it.

The issue filer uses this value when filing issues.

@sebastienros 