### PR TITLE
Handle EventPipeEventSource being disposed

### DIFF
--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -4971,7 +4971,7 @@ namespace Microsoft.Crank.Agent
                     source.Process();
                     Log.Info($"Event pipe source stopped ({job.Service}:{job.Id})");
                 }
-                catch (Exception e)
+                catch (Exception e) when (e is not ObjectDisposedException)
                 {
                     if (e.Message == "Read past end of stream.")
                     {


### PR DESCRIPTION
Do not log an error if `EventPipeEventSource` tries to read the network stream after it's disposed of.

Looks like there's the possibility of a race between stopping the source and the network stream being disposed of that causes an `ObjectDisposedException` to be thrown and logged when shutting things down.

It seems benign to me, so it just isn't logged now. I had a look at the code and I couldn't spot an obvious way that the code that was incorrect that could have been changed to not have the exception happen at all in the first place, but I might just not have fully understood the code's flow.

An excerpt from some logs where I spotted this are below.

```sh
[08:43:23 INF] Driver stopping job '4'
[08:43:24 INF] Processing job 'load' (4) in state Stopped
[08:43:24 INF] Job 'load' (4) has stopped, waiting for the driver to delete it
[08:43:24 INF] Process has exited with exit code 0 (load:4)
[08:43:24 INF] Driver deleting job '4'
[08:43:24 INF] Driver stopping job '3'
[08:43:25 INF] Processing job 'application' (3) in state Stopping
[08:43:25 INF] Stopping job 'application' (3)
[08:43:25 INF] Stopping heartbeat (application:3)
[08:43:25 INF] Heartbeat stopped for (application:3)
[08:43:25 INF] Stopping counters event pipes for job 'application' (3)
[08:43:25 INF] Stopping event pipe session (application:3)...
[08:43:25 INF] Reason: counters are being stopped
[08:43:25 INF] Event pipe source created
[08:43:25 INF] Processing event pipe source (application:3)...
[08:43:25 INF] Event pipe session stopped (application:3)
Error: 25 ERR] [ERROR] source.Process()
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'Microsoft.Diagnostics.NETCore.Client.ExposedSocketNetworkStream'.
   at System.Net.Sockets.NetworkStream.<ThrowIfDisposed>g__ThrowObjectDisposedException|63_0()
   at System.Net.Sockets.NetworkStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at FastSerialization.IOStreamStreamReader.Fill(Int32 minimum)
   at FastSerialization.MemoryStreamReader.ReadInt32()
   at FastSerialization.Deserializer.Read(Int32& ret)
   at FastSerialization.SerializationType.FastSerialization.IFastSerializable.FromStream(Deserializer deserializer)
   at FastSerialization.Deserializer.ReadObjectDefinition(Tags tag, StreamLabel objectLabel)
   at FastSerialization.Deserializer.ReadObject()
   at FastSerialization.Deserializer.ReadObjectDefinition(Tags tag, StreamLabel objectLabel)
   at FastSerialization.Deserializer.ReadObject()
   at Microsoft.Diagnostics.Tracing.EventPipeEventSource.Process()
   at Microsoft.Crank.Agent.Startup.<>c__DisplayClass110_0.<StartCountersAsync>b__2() in C:\Coding\dotnet\crank\src\Microsoft.Crank.Agent\Startup.cs:line 4971
[08:43:25 INF] Counters stopped for job 'application' (3)
[08:43:25 INF] Invoking SIGTERM ...
[08:43:25 INF] info: Microsoft.Hosting.Lifetime[0]
[08:43:25 INF]       Application is shutting down...
[08:43:25 INF] Process has stopped
[08:43:25 INF] Process stopped (Stopped)
[08:43:25 INF] Driver deleting job '3'
```