### PR TITLE
Add support for multiple pipelines

### DIFF
--- a/src/Microsoft.Crank.PullRequestBot/Program.cs
+++ b/src/Microsoft.Crank.PullRequestBot/Program.cs
@@ -286,13 +286,6 @@ namespace Microsoft.Crank.PullRequestBot
 
                     try
                     {
-                        if (!HasThingsToRun(command.Benchmarks, command.Profiles, command.Components))
-                        {
-                            Console.WriteLine("Arguments don't match a valid command.");
-                            
-                            continue;
-                        }
-
                         await _githubClient.Issue.Comment.Create(owner, name, command.PullRequest.Number, ApplyThumbprint($"Benchmark started for __{string.Join(", ", command.Benchmarks)}__ on __{string.Join(", ", command.Profiles)}__ with __{string.Join(", ", command.Components)}__"));
 
                         var results = await RunBenchmark(command);
@@ -321,13 +314,6 @@ namespace Microsoft.Crank.PullRequestBot
             }
 
             return 0;
-        }
-        private static bool HasThingsToRun(string[] benchmarkNames, string[] profileNames, string[] componentNames)
-        {
-            return benchmarkNames.Any(x => !_configuration.Benchmarks.ContainsKey(x))
-                   && profileNames.Any(x => !_configuration.Profiles.ContainsKey(x))
-                   && componentNames.Any(x => !_configuration.Components.ContainsKey(x))
-                   ;
         }
 
         private static void CreateThumbprint()

--- a/src/Microsoft.Crank.PullRequestBot/Program.cs
+++ b/src/Microsoft.Crank.PullRequestBot/Program.cs
@@ -11,8 +11,11 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Security.Cryptography;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.RegularExpressions;
+using System.Text.Unicode;
 using System.Threading.Tasks;
 using Manatee.Json;
 using Manatee.Json.Schema;
@@ -33,7 +36,7 @@ namespace Microsoft.Crank.PullRequestBot
         private static readonly HttpClientHandler _httpClientHandler;
 
         // Any comment made by this bot should contain the thumbprint to detect benchmark commands have already been processed 
-        private const string Thumbprint = "<!-- pullrequestthumbprint -->";
+        private static string Thumbprint = "<!-- pullrequestthumbprint {0} -->";
 
         private const string BenchmarkCommand = "/benchmark";
         private const string BaseFilename = "base.json";
@@ -153,7 +156,7 @@ namespace Microsoft.Crank.PullRequestBot
                 // rather than just use a different base address for the API.
                 await UpgradeAuthenticatedClient();
             }
-            else if (!string.IsNullOrEmpty(_options.AccessToken) || !string.IsNullOrEmpty(_options.AppId) || !string.IsNullOrEmpty(_options.AppId))
+            else if (!string.IsNullOrEmpty(_options.AccessToken) || !string.IsNullOrEmpty(_options.AppId) || !string.IsNullOrEmpty(_options.AppKey))
             {
                 // If authentication information is provided pre-authenticate since it will prevent some rate limiting exception for read-only API calls.
                 await UpgradeAuthenticatedClient();
@@ -227,18 +230,25 @@ namespace Microsoft.Crank.PullRequestBot
                     return -1;
                 }
 
+                // Check if the arguments are available in the configuration file
+
                 var benchmarkNames = options.Benchmarks.Split(',', StringSplitOptions.RemoveEmptyEntries);
                 var profileNames = options.Profiles.Split(',', StringSplitOptions.RemoveEmptyEntries);
-                var buildNames = options.Components.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                var componentNames = options.Components.Split(',', StringSplitOptions.RemoveEmptyEntries);
 
-                if (!ArgumentsValid(benchmarkNames, profileNames, buildNames, markdown: false, out var help))
+                benchmarkNames = benchmarkNames.Intersect(_configuration.Benchmarks.Keys).ToArray();
+                profileNames = profileNames.Intersect(_configuration.Profiles.Keys).ToArray();
+                componentNames = componentNames.Intersect(_configuration.Components.Keys).ToArray();
+
+                if (!benchmarkNames.Any() || !profileNames.Any() || !componentNames.Any())
                 {
-                    Console.WriteLine(help);
-
-                    return -1;
+                    Console.WriteLine("Arguments don't match a valid command.");
+                    return 0;
                 }
 
-                var command = new Command { PullRequest = pr, Benchmarks = benchmarkNames, Profiles = profileNames, Components = buildNames };
+                CreateThumbprint();
+
+                var command = new Command { PullRequest = pr, Benchmarks = benchmarkNames, Profiles = profileNames, Components = componentNames };
 
                 var results = await RunBenchmark(command);
 
@@ -277,6 +287,13 @@ namespace Microsoft.Crank.PullRequestBot
 
                     try
                     {
+                        if (!HasThingsToRun(command.Benchmarks, command.Profiles, command.Components))
+                        {
+                            Console.WriteLine("Arguments don't match a valid command.");
+                            
+                            continue;
+                        }
+
                         await _githubClient.Issue.Comment.Create(owner, name, command.PullRequest.Number, ApplyThumbprint($"Benchmark started for __{string.Join(", ", command.Benchmarks)}__ on __{string.Join(", ", command.Profiles)}__ with __{string.Join(", ", command.Components)}__"));
 
                         var results = await RunBenchmark(command);
@@ -305,6 +322,21 @@ namespace Microsoft.Crank.PullRequestBot
             }
 
             return 0;
+        }
+        private static bool HasThingsToRun(string[] benchmarkNames, string[] profileNames, string[] componentNames)
+        {
+            return benchmarkNames.Any(x => !_configuration.Benchmarks.ContainsKey(x))
+                   && profileNames.Any(x => !_configuration.Profiles.ContainsKey(x))
+                   && componentNames.Any(x => !_configuration.Components.ContainsKey(x))
+                   ;
+        }
+
+        private static void CreateThumbprint()
+        {
+            // Create a unique thumbprint per configuration file such that multiple pipelines can process the same PR with different arguments (linux/windows, x64/arm64)
+            var identifier = Convert.ToBase64String(MD5.HashData(Encoding.UTF8.GetBytes(_options.Config)));
+
+            Thumbprint = string.Format(Thumbprint, HtmlEncoder.Default.Encode(identifier));
         }
 
         private static string FormatResult(Result result)
@@ -380,21 +412,34 @@ namespace Microsoft.Crank.PullRequestBot
 
                                 var benchmarkNames = (arguments.Length > 0 ? arguments[0] : "").Split(',', StringSplitOptions.RemoveEmptyEntries);
                                 var profileNames = (arguments.Length > 1 ? arguments[1] : "").Split(',', StringSplitOptions.RemoveEmptyEntries);
-                                var buildNames = (arguments.Length > 2 ? arguments[2] : "").Split(',', StringSplitOptions.RemoveEmptyEntries);
+                                var componentNames = (arguments.Length > 2 ? arguments[2] : "").Split(',', StringSplitOptions.RemoveEmptyEntries);
 
-                                if (!ArgumentsValid(benchmarkNames, profileNames, buildNames, markdown: true, out var help))
+                                // If some arguments are missing render the help text as a new comment
+                                if (!benchmarkNames.Any() || !profileNames.Any() || !componentNames.Any())
                                 {
-                                    await _githubClient.Issue.Comment.Create(owner, name, pr.Number, ApplyThumbprint(help));
+                                    await _githubClient.Issue.Comment.Create(owner, name, pr.Number, ApplyThumbprint(GetHelp(markdown: true)));
 
                                     yield break;
                                 }
+
+                                // Check if the arguments are available in the configuration file
+                                benchmarkNames = benchmarkNames.Intersect(_configuration.Benchmarks.Keys).ToArray();
+                                profileNames = profileNames.Intersect(_configuration.Profiles.Keys).ToArray();
+                                componentNames = componentNames.Intersect(_configuration.Components.Keys).ToArray();
+
+                                if (!benchmarkNames.Any() || !profileNames.Any() || !componentNames.Any())
+                                {
+                                    // Skip comment
+                                    yield break;
+                                }
+
 
                                 // Default command values
                                 yield return new Command
                                 {
                                     Benchmarks = benchmarkNames.Any() ? benchmarkNames : new[] { _configuration.Benchmarks.First().Key },
                                     Profiles = profileNames.Any() ? profileNames : new[] { _configuration.Profiles.First().Key },
-                                    Components = buildNames.Any() ? buildNames : new[] { _configuration.Components.First().Key },
+                                    Components = componentNames.Any() ? componentNames : new[] { _configuration.Components.First().Key },
                                     PullRequest = pr,
                                 };
                             }
@@ -421,48 +466,38 @@ namespace Microsoft.Crank.PullRequestBot
             }            
         }
 
-        public static bool ArgumentsValid(string[] benchmarkNames, string[] profileNames, string[] buildNames, bool markdown, out string help)
+        public static string GetHelp(bool markdown)
         {
-            if ((!benchmarkNames.Any() || benchmarkNames.Any(x => !_configuration.Benchmarks.ContainsKey(x)))
-                    || (!profileNames.Any() || profileNames.Any(x => !_configuration.Profiles.ContainsKey(x)))
-                    || (!buildNames.Any() || buildNames.Any(x => !_configuration.Components.ContainsKey(x))))
+            string help =
+                "Crank Pull Request Bot\n" +
+                "\n" +
+                "`/benchmark <benchmarks[,...]> <profiles[,...]> <components,[...]>`\n"
+                ;
+
+            help += $"\nBenchmarks: \n";
+            foreach (var entry in _configuration.Benchmarks)
             {
-                // Render help
-
-                help =
-                    "Crank - Pull Request Bot\n" +
-                    "\n" +
-                    "`/benchmark <benchmarks[,...]> <profiles[,...]> <components,[...]>`\n"
-                    ;
-
-                help += $"\nBenchmarks: \n";
-                foreach (var entry in _configuration.Benchmarks)
-                {
-                    help += $"- `{entry.Key}`: {entry.Value.Description}\n";
-                }
-
-                help += $"\nProfiles: \n";
-                foreach (var entry in _configuration.Profiles)
-                {
-                    help += $"- `{entry.Key}`: {entry.Value.Description}\n";
-                }
-
-                help += $"\nComponents: \n";
-                foreach (var entry in _configuration.Components)
-                {
-                    help += $"- `{entry.Key}`\n";
-                }
-
-                if (!markdown)
-                {
-                    help = help.Replace("`", "");
-                }
-
-                return false;
+                help += $"- `{entry.Key}`: {entry.Value.Description}\n";
             }
 
-            help = "";
-            return true;
+            help += $"\nProfiles: \n";
+            foreach (var entry in _configuration.Profiles)
+            {
+                help += $"- `{entry.Key}`: {entry.Value.Description}\n";
+            }
+
+            help += $"\nComponents: \n";
+            foreach (var entry in _configuration.Components)
+            {
+                help += $"- `{entry.Key}`\n";
+            }
+
+            if (!markdown)
+            {
+                help = help.Replace("`", "");
+            }
+
+            return help;
         }
 
         public static async Task<Configuration> LoadConfigurationAsync(string configurationFilenameOrUrl)

--- a/src/Microsoft.Crank.PullRequestBot/Program.cs
+++ b/src/Microsoft.Crank.PullRequestBot/Program.cs
@@ -15,7 +15,6 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.RegularExpressions;
-using System.Text.Unicode;
 using System.Threading.Tasks;
 using Manatee.Json;
 using Manatee.Json.Schema;


### PR DESCRIPTION
With this change only the profiles/benchmarks/components that are available in the configuration file will be used. The goal is to be able to create as many configuration file as there are components/profiles compatible combinations and have different pipelines use each file.

Example:
For the runtime repository benchmarks can target windows/linux and x64/arm64. The idea is to create 4 files, each of them will have the scripts required for a shell/arch couple, and the profiles it supports.

Running a benchmark with "coreclr aspnet-arm-lin plaintext" will then only work for the configuration file that contains the arm/lin commands, using bash as the shell and targeting linux.

If a command contains "coreclr aspnet-arm-lin,aspnet-arm-win plaintext" then one pipeline will be able to run the lin one and another pipeline will run the win one. Even though there is a single command.
