### PR TITLE
Apply Fluid templates to PullRequestBot configs

### DIFF
--- a/src/Microsoft.Crank.PullRequestBot/Configuration.cs
+++ b/src/Microsoft.Crank.PullRequestBot/Configuration.cs
@@ -4,12 +4,14 @@
 
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Crank.PullRequestBot
 {
     public class Configuration
     {
         public string Defaults { get; set; }
+        public Dictionary<string, object> Variables { get; } = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
         public Dictionary<string, Build> Components { get; set; } = new Dictionary<string, Build>(StringComparer.OrdinalIgnoreCase);
         public Dictionary<string, Profile> Profiles { get; set; } = new Dictionary<string, Profile>(StringComparer.OrdinalIgnoreCase);
         public Dictionary<string, Benchmark> Benchmarks { get; set; } = new Dictionary<string, Benchmark>(StringComparer.OrdinalIgnoreCase);
@@ -25,6 +27,7 @@ namespace Microsoft.Crank.PullRequestBot
     {
         public string Description { get; set; }
         public string Arguments { get; set; }
+        public Dictionary<string, object> Variables { get; } = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
     }
 
     public class Build

--- a/src/Microsoft.Crank.PullRequestBot/Microsoft.Crank.PullRequestBot.csproj
+++ b/src/Microsoft.Crank.PullRequestBot/Microsoft.Crank.PullRequestBot.csproj
@@ -10,6 +10,7 @@
     <OutputType>Exe</OutputType>
     <Authors>Microsoft</Authors>
     <PackageId>Microsoft.Crank.PullRequestBot</PackageId>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,6 +30,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />
     <PackageReference Include="Manatee.Json" Version="13.0.5" />
+    <PackageReference Include="Fluid.Core" Version="2.2.6" />
 
     <!-- Force version for Component Governance compliance -->
     <PackageReference Include="System.Net.Http" Version="4.3.4">

--- a/src/Microsoft.Crank.PullRequestBot/pullrequestbot.schema.json
+++ b/src/Microsoft.Crank.PullRequestBot/pullrequestbot.schema.json
@@ -52,7 +52,7 @@
         },
         "variables": {
           "type": "object",
-          "title": "Variables available for this benchmark"
+          "title": "Variables used to run this benchmark"
         }
       }
     }

--- a/src/Microsoft.Crank.PullRequestBot/pullrequestbot.schema.json
+++ b/src/Microsoft.Crank.PullRequestBot/pullrequestbot.schema.json
@@ -49,6 +49,10 @@
         "arguments": {
           "type": "string",
           "description": "The crank arguments to add when the benchmark is selected."
+        },
+        "variables": {
+          "type": "object",
+          "title": "Variables available for this benchmark"
         }
       }
     }
@@ -60,6 +64,10 @@
     "defaults": {
       "type": "string",
       "title": "Default arguments passed to the crank command line for all benchmarks of this file."
+    },
+    "variables": {
+      "type": "object",
+      "title": "The global variables"
     },
     "components": {
       "type": "object",


### PR DESCRIPTION
Allows to use templates in PullRequestBot configs in all Crank arguments (`defaults`, `benchmark.arguments`, `profile.arguments`, `component.arguments`, command-line passed `arguments`)

Example of config with templates:

```yml
components:
    runtime:
      ....
      arguments: '--{{job}}.options.outputFiles ..\runtime\artifacts\tests\coreclr\windows.x64.Release\tests\Core_Root\'

defaults: '--{{job}}.framework net7.0'

variables:
    job: client

benchmarks:
    json:
      description: TechEmpower JSON Scenario - ASP.NET Platform implementation
      arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario plaintext
      variables:
        job: application

    http-client-get8k-h1:
      description: HttpClient GET 8K - HTTP/1.1
      arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/httpclient.benchmarks.yml --scenario httpclient-kestrel-get --variable useHttps=true --variable httpVersion="1.1" --variable responseSize=8192 --variable concurrencyPerHttpClient=100 --server.framework net7.0

    ....
```

Resulted crank calls:

```
crank --application.framework net7.0 --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario json --profile aspnet-perf-win --application.options.outputFiles ..\runtime\artifacts\tests\coreclr\windows.x64.Release\tests\Core_Root\ --json C:\Users\knatalia\dev\tmp\json.base.json
```

```
crank --client.framework net7.0 --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/httpclient.benchmarks.yml --scenario httpclient-kestrel-post --variable useHttps=true --variable httpVersion=1.1 --variable requestContentSize=8192 --variable concurrencyPerHttpClient=100 --server.framework net7.0 --profile aspnet-perf-win --client.options.outputFiles ..\runtime\artifacts\tests\coreclr\windows.x64.Release\tests\Core_Root\ --json C:\Users\knatalia\dev\tmp\http-client-post8k-h1.base.json
```