### PR TITLE
Treat remaining PR comment text as Crank arguments

### DIFF
--- a/src/Microsoft.Crank.PullRequestBot/Command.cs
+++ b/src/Microsoft.Crank.PullRequestBot/Command.cs
@@ -12,5 +12,6 @@ namespace Microsoft.Crank.PullRequestBot
         public string[] Benchmarks { get; set; }
         public string[] Profiles { get; set; }
         public string[] Components { get; set; }
+        public string Arguments { get; set; }
     }
 }


### PR DESCRIPTION
Similar to crank-pr `--arguments` option, but from PR comment.

PR comment would look like:
`/benchmark microbenchmarks aspnet-citrine-win runtime --variable filter=System.Memory*`