### PR TITLE
Add precheck, retries and parameter to pass link to logs to PR bot

### DIFF
--- a/src/Microsoft.Crank.PullRequestBot/BotOptions.cs
+++ b/src/Microsoft.Crank.PullRequestBot/BotOptions.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Crank.PullRequestBot
         public bool Debug { get; set; }
         public Uri GitHubBaseUrl { get; set; }
         public string Arguments { get; set; }
+        public Uri ExternalLogUri { get; set; }
 
         public void Validate()
         {

--- a/src/Microsoft.Crank.PullRequestBot/ProcessUtil.cs
+++ b/src/Microsoft.Crank.PullRequestBot/ProcessUtil.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Crank.PullRequestBot
 
                 if (throwOnError && process.ExitCode != 0)
                 {
-                    processLifetimeTask.TrySetException(new InvalidOperationException($"Command {filename} {arguments} returned exit code {process.ExitCode}"));
+                    processLifetimeTask.TrySetException(new InvalidOperationException($"Command '{filename} {arguments}' returned exit code {process.ExitCode}"));
                 }
                 else
                 {
@@ -163,6 +163,11 @@ namespace Microsoft.Crank.PullRequestBot
 
             if (result != processLifetimeTask.Task)
             {
+                if (log)
+                {
+                    Console.WriteLine($"Command '{filename} {arguments}' {(cancellationToken.IsCancellationRequested ? "is canceled" : "timed out")}, process {process.Id} will be terminated");
+                }
+
                 if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     sys_kill(process.Id, sig: 2); // SIGINT
@@ -180,7 +185,7 @@ namespace Microsoft.Crank.PullRequestBot
 
                     if (!process.HasExited)
                     {
-                        process.Kill();
+                        process.Kill(entireProcessTree: true);
                     }
                 }
             }

--- a/src/Microsoft.Crank.PullRequestBot/Program.cs
+++ b/src/Microsoft.Crank.PullRequestBot/Program.cs
@@ -881,25 +881,32 @@ namespace Microsoft.Crank.PullRequestBot
                 int exitCode = 1;
                 string result = null;
 
-                if (!options.CaptureOutput)
+                try
                 {
-                    exitCode = Crank.Controller.Program.Main(args);
-                }
-                else
-                {
-                    using var sw = new StringWriter();
-                    var consoleOut = Console.Out;
-                    try
+                    if (!options.CaptureOutput)
                     {
-                        Console.SetOut(sw);
                         exitCode = Crank.Controller.Program.Main(args);
                     }
-                    finally
+                    else
                     {
-                        Console.SetOut(consoleOut);
-                        Console.WriteLine(sw.ToString());
+                        using var sw = new StringWriter();
+                        var consoleOut = Console.Out;
+                        try
+                        {
+                            Console.SetOut(sw);
+                            exitCode = Crank.Controller.Program.Main(args);
+                        }
+                        finally
+                        {
+                            Console.SetOut(consoleOut);
+                            Console.WriteLine(sw.ToString());
+                        }
+                        result = sw.ToString();
                     }
-                    result = sw.ToString();
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
                 }
 
                 if (exitCode == 0)

--- a/src/Microsoft.Crank.PullRequestBot/README.md
+++ b/src/Microsoft.Crank.PullRequestBot/README.md
@@ -28,6 +28,7 @@ Options:
   --config <config> (REQUIRED)           The path to a configuration file.
   --version                              Show version information
   --age                                  The age of the most recent comment to look for in minutes. Default is 60.
+  --external-log-uri <external-log-uri>  Link to the logs (e.g. in AzDO) to publish in the start comment.
   -?, -h, --help                         Show help and usage information
 ```
 


### PR DESCRIPTION
- Add pre-check for crank command (run without component arguments), cancel build on pre-check failure
- Fix process termination in `ProcessUtil`
- Add retries when running crank (except for crank compare) -- on non-zero exit code
- Add crank logs to console without waiting (stop capturing output in `StringWriter`, except for crank compare)
- Add `--external-log-uri` parameter to pass the logs link, add the link to start comment
- Add arguments from /benchmark comment to start comment
- Update PR bot help comment

Contributes to https://github.com/dotnet/runtime/issues/77215

cc @sebastienros @kunalspathak 