### PR TITLE
Fix percentiles

### DIFF
--- a/src/Microsoft.Crank.Controller/default.config.yml
+++ b/src/Microsoft.Crank.Controller/default.config.yml
@@ -898,5 +898,5 @@ onResultsCreating:
     var percentile99 = x => percentile(x, 99)
     var percentile95 = x => percentile(x, 95)
     var percentile90 = x => percentile(x, 90)
-    var percentile75 = x => percentile(x, 90)
-    var percentile50 = x => percentile(x, 90)
+    var percentile75 = x => percentile(x, 75)
+    var percentile50 = x => percentile(x, 50)


### PR DESCRIPTION
There was a copy-paste error where percentile75 and percentile50 were using `90` for the percentiles.

cc @sebastienros @mitchdenny 