### PR TITLE
[h2load] Reset Output before actual load

### DIFF
--- a/src/Microsoft.Crank.Jobs.H2Load/Program.cs
+++ b/src/Microsoft.Crank.Jobs.H2Load/Program.cs
@@ -117,6 +117,7 @@ namespace H2LoadClient
                 Duration = tmpValues.Duration;
                 Warmup = tmpValues.Warmup;
                 Threads = tmpValues.Threads;
+                Output = "";
                 
                 using (var process = StartProcess())
                 {


### PR DESCRIPTION
Output is aggregated on the same content after the first request run. This means the "parse output" step will find the results from the first run instead of the second one.