### PR TITLE
Allow project relative file downloads

### DIFF
--- a/src/Microsoft.Crank.Agent/Controllers/JobsController.cs
+++ b/src/Microsoft.Crank.Agent/Controllers/JobsController.cs
@@ -658,7 +658,7 @@ namespace Microsoft.Crank.Agent.Controllers
                 var rootPath = Directory.GetParent(job.BasePath).FullName;
 
                 // Assume ~/ means relative to the project, otherwise it's relative to the application folder (job.BasePath)
-                var isRelativeToProject = String.IsNullOrEmpty(job.Source.DockerFile) && path.StartsWith("~/") || path.StartsWith("~\\");
+                var isRelativeToProject = String.IsNullOrEmpty(job.Source.DockerFile) && (path.StartsWith("~/") || path.StartsWith("~\\"));
                 
                 if (isRelativeToProject)
                 {
@@ -732,7 +732,7 @@ namespace Microsoft.Crank.Agent.Controllers
                 var rootPath = Directory.GetParent(job.BasePath).FullName;
 
                 // Assume ~/ means relative to the project, otherwise it's relative to the application folder (job.BasePath)
-                var isRelativeToProject = String.IsNullOrEmpty(job.Source.DockerFile) && path.StartsWith("~/") || path.StartsWith("~\\");
+                var isRelativeToProject = String.IsNullOrEmpty(job.Source.DockerFile) && (path.StartsWith("~/") || path.StartsWith("~\\"));
 
                 if (isRelativeToProject)
                 {

--- a/src/Microsoft.Crank.Agent/Controllers/JobsController.cs
+++ b/src/Microsoft.Crank.Agent/Controllers/JobsController.cs
@@ -758,7 +758,7 @@ namespace Microsoft.Crank.Agent.Controllers
                 {
                     return Json(
                         Directory.GetFiles(Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath))
-                        .Select(x => x.Substring(job.BasePath.Length).TrimStart('/', '\\'))
+                        .Select(x => x.Substring(rootPath.Length).TrimStart('/', '\\'))
                         .ToArray()
                         );
                 }

--- a/src/Microsoft.Crank.Controller/Documentation.cs
+++ b/src/Microsoft.Crank.Controller/Documentation.cs
@@ -90,7 +90,7 @@ internal class Documentation
   --[JOB].options.fetchOutput <filename>                        The name of the fetched archive. Can be a file prefix (app will add *.DATE*.zip) , or a specific name (end in *.zip) and no DATE* will be added e.g., c:\publishedapps\myApp
   --[JOB].options.displayOutput <true|false>                    Whether to download and display the standard output of the benchmark.
   --[JOB].options.displayBuild <true|false>                     Whether to download and display the standard output of the build step (works for .NET and Docker).
-  --[JOB].options.downloadFiles <filename|pattern>              The name of the file(s) to download. The working directory is the published folder.
+  --[JOB].options.downloadFiles <filename|pattern>              The name of the file(s) to download. The working directory is the published folder. Use '~/' to use the project's location as the base folder.
   --[JOB].options.downloadFilesOutput <path>                    A path where the files will be downloaded.
 
   ## Files

--- a/src/Microsoft.Crank.Controller/JobConnection.cs
+++ b/src/Microsoft.Crank.Controller/JobConnection.cs
@@ -1223,7 +1223,7 @@ namespace Microsoft.Crank.Controller
                     file = file.Substring(2);
                 }
 
-                var filename = Path.Combine(output ?? "", file);
+                var filename = Path.Combine(output ?? "", Path.GetFileName(file));
                 filename = Path.GetFullPath(filename);
 
                 if (!Directory.Exists(Path.GetDirectoryName(filename)))

--- a/src/Microsoft.Crank.Controller/JobConnection.cs
+++ b/src/Microsoft.Crank.Controller/JobConnection.cs
@@ -1218,6 +1218,11 @@ namespace Microsoft.Crank.Controller
                 var uri = Combine(_serverJobUri, "/download?path=" + HttpUtility.UrlEncode(file));
                 Log.Verbose("GET " + uri);
 
+                if (file.StartsWith("~/") || file.StartsWith("~\\"))
+                {
+                    file = file.Substring(2);
+                }
+
                 var filename = Path.Combine(output ?? "", file);
                 filename = Path.GetFullPath(filename);
 

--- a/src/Microsoft.Crank.Controller/README.md
+++ b/src/Microsoft.Crank.Controller/README.md
@@ -113,7 +113,7 @@ Options:
   --[JOB].options.fetchOutput <filename>                                   The name of the fetched archive. Can be a file prefix (app will add *.DATE*.zip) , or a specific name (end in *.zip) and no DATE* will be added e.g., c:\publishedapps\myApp
   --[JOB].options.displayOutput <true|false>                               Whether to download and display the standard output of the benchmark.
   --[JOB].options.displayBuild <true|false>                                Whether to download and display the standard output of the build step (works for .NET and Docker).
-  --[JOB].options.downloadFiles <filename|pattern>                         The name of the file(s) to download. The working directory is the published folder.
+  --[JOB].options.downloadFiles <filename|pattern>                         The name of the file(s) to download. The working directory is the published folder. Use '~/' to use the project's location as the base folder.
   --[JOB].options.downloadFilesOutput <path>                               A path where the files will be downloaded.
 
   ## Files

--- a/test/Microsoft.Crank.IntegrationTests/CommonTests.cs
+++ b/test/Microsoft.Crank.IntegrationTests/CommonTests.cs
@@ -160,6 +160,35 @@ namespace Microsoft.Crank.IntegrationTests
             Assert.Equal(expectedOutputFileContent, File.ReadAllText(expectedOutputFilename));
         }
 
+        [Fact]
+        public async Task DownloadProjectFile()
+        {
+            _output.WriteLine($"[TEST] Starting controller");
+
+            // Create a local folder to download file into
+            var outputFileDirectory = Path.Combine(_crankTestsDirectory, "projecfiles");
+            Directory.CreateDirectory(outputFileDirectory);
+
+            var expectedOutputFilename = Path.Combine(outputFileDirectory, "hello.csproj");
+
+            var result = await ProcessUtil.RunAsync(
+                "dotnet",
+                $"exec {Path.Combine(_crankDirectory, "crank.dll")} --config ./assets/hello.benchmarks.yml --scenario hello --profile local --application.options.downloadFiles ~/hello.csproj --application.options.downloadFilesOutput {outputFileDirectory}",
+                workingDirectory: _crankTestsDirectory,
+                captureOutput: true,
+                timeout: DefaultTimeOut,
+                throwOnError: false,
+                outputDataReceived: t => { _output.WriteLine($"[CTL] {t}"); }
+            );
+
+            Assert.Equal(0, result.ExitCode);
+
+            _output.WriteLine(_agent.FlushOutput());
+
+            Assert.Contains("Uploading", result.StandardOutput);
+            Assert.True(File.Exists(expectedOutputFilename));
+        }
+
         [SkipOnMacOs]
         public async Task CollectDump()
         {


### PR DESCRIPTION
Necessary to download files from the csproj folder or `obj/,...`