### PR TITLE
Match 'name: value' header format in h2load wrapper

### DIFF
--- a/src/Microsoft.Crank.Jobs.H2Load/Program.cs
+++ b/src/Microsoft.Crank.Jobs.H2Load/Program.cs
@@ -59,14 +59,15 @@ namespace H2LoadClient
                 Protocol = optionProtocol.Value();
 
                 Headers = new Dictionary<string, string>();
+
                 foreach (var header in optionHeaders.ParsedValues)
                 {
-                    var headerParts = header.Split('=');
+                    var headerParts = header.Split(':', 2, StringSplitOptions.TrimEntries);
                     var key = headerParts[0];
                     var value = headerParts[1];
                     Headers.Add(key, value);
 
-                    Console.WriteLine($"Header: {key}={value}");
+                    Console.WriteLine($"Header: '{key}: {value}'");
                 }
 
                 if (Headers.Count == 0)

--- a/src/Microsoft.Crank.Jobs.H2Load/h2load.yml
+++ b/src/Microsoft.Crank.Jobs.H2Load/h2load.yml
@@ -1,8 +1,8 @@
 ﻿variables:
   headers:
     none: ''
-    grpc: "--header content-type=application/grpc --header TE=trailers"
-    grpcDeadline: "--header content-type=application/grpc --header TE=trailers --header grpc-timeout=100S"
+    grpc: '--header "content-type: application/grpc" --header "TE: trailers"'
+    grpcDeadline: '--header "content-type: application/grpc" --header "TE: trailers" --header "grpc-timeout: 100S"'
   presetHeaders: none
 
 jobs:


### PR DESCRIPTION
This PR switches h2load to the header format used by bombardier - `key: value` instead of `key=value`.

[Proxies runs](https://dev.azure.com/dnceng/internal/_build/results?buildId=2121723&view=logs&j=0d02efdf-002e-5960-fff9-d39f49e676e1&t=e0f008ef-8e2e-5503-fdc6-88c09c6b8cc3&l=35) for h2 are failing after https://github.com/aspnet/Benchmarks/pull/1798

```console
-c 28 -t 28 -m 100 -d 15 -w 5 -n 0 -u  https://10.0.0.102:8080/?s=100  -p h2c --header "Accept: text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7" --header "Connection: keep-alive"
```

```
Header: Accept: text/plain,text/html;q=0.9,application/xhtml+xml;q
[STDERR] Unhandled exception. System.IndexOutOfRangeException: Index was outside the bounds of the array.
[STDERR]    at H2LoadClient.Program.<>c__DisplayClass52_0.<<Main>b__0>d.MoveNext()
[STDERR] --- End of stack trace from previous location ---
[STDERR]    at McMaster.Extensions.CommandLineUtils.CommandLineApplicationExtensions.<>c__DisplayClass9_0.<<OnExecuteAsync>b__0>d.MoveNext()
[STDERR] --- End of stack trace from previous location ---
[STDERR]    at McMaster.Extensions.CommandLineUtils.CommandLineApplication.ExecuteAsync(String[] args, CancellationToken cancellationToken)
[STDERR]    at H2LoadClient.Program.Main(String[] args) in /tmp/benchmarks-agent/benchmarks-server-1/h2load/crank/src/Microsoft.Crank.Jobs.H2Load/Program.cs:line 148
[STDERR]    at H2LoadClient.Program.<Main>(String[] args)
```