### PR TITLE
Fix crank subcommand help information

### DIFF
--- a/src/Microsoft.Crank.Controller/Program.cs
+++ b/src/Microsoft.Crank.Controller/Program.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Crank.Controller
                 OptionsComparison = StringComparison.OrdinalIgnoreCase,
             };
 
-            app.HelpOption("-?|-h|--help");
+            app.HelpOption("-?|-h|--help", true);
 
             _configOption = app.Option("-c|--config", "Configuration file or url.", CommandOptionType.MultipleValue);
             _scenarioOption = app.Option("-s|--scenario", "Scenario to execute.", CommandOptionType.SingleValue);


### PR DESCRIPTION
For #485 , fix the help information of `crank compare`