### PR TITLE
Fix duplicate folder name when use downloadFiles options

### DIFF
--- a/src/Microsoft.Crank.Controller/JobConnection.cs
+++ b/src/Microsoft.Crank.Controller/JobConnection.cs
@@ -1200,7 +1200,7 @@ namespace Microsoft.Crank.Controller
                     var uri = Combine(_serverJobUri, "/download?path=" + HttpUtility.UrlEncode(f));
                     Log.Verbose("GET " + uri);
 
-                    var filename = Path.Combine(output ?? "", Path.GetDirectoryName(file), f);
+                    var filename = Path.Combine(output ?? "", f);
                     filename = Path.GetFullPath(filename);
 
                     if (!Directory.Exists(Path.GetDirectoryName(filename)))


### PR DESCRIPTION
fixed #282 

------
Using the following command to test

```
crank --config .\samples\local\local.benchmarks.yml --scenario hello --profile local --application.options.downloadFiles App_Data/logs/*.* 
```

Before modification

![](https://user-images.githubusercontent.com/8394988/223713499-62dc9f6d-4f79-41ba-899d-7077a3c353ea.png)

After modification

![](https://user-images.githubusercontent.com/8394988/223714332-ce5ebadd-9c05-4adc-96ac-02cd0961f9a8.png)
