### PR TITLE
Variables should be stored automatically in the results

### DIFF
--- a/src/Microsoft.Crank.Controller/Program.cs
+++ b/src/Microsoft.Crank.Controller/Program.cs
@@ -1171,6 +1171,11 @@ namespace Microsoft.Crank.Controller
                                 {
                                     yield return job.Key + "." + e.Key;
                                 }
+
+                                foreach (var e in job.Value.Variables)
+                                {
+                                    yield return job.Key + "." + e.Key;
+                                }
                             }
 
                             foreach (var p in result.JobResults.Properties)
@@ -1196,6 +1201,11 @@ namespace Microsoft.Crank.Controller
                                 }
 
                                 foreach (var e in job.Value.Environment)
+                                {
+                                    yield return Convert.ToString(e.Value, System.Globalization.CultureInfo.InvariantCulture);
+                                }
+
+                                foreach (var e in job.Value.Variables)
                                 {
                                     yield return Convert.ToString(e.Value, System.Globalization.CultureInfo.InvariantCulture);
                                 }
@@ -2499,6 +2509,15 @@ namespace Microsoft.Crank.Controller
                     .ToArray();
 
                 jobResult.Results = AggregateAndReduceResults(jobConnections, engine, resultDefinitions.Values.ToList());
+
+                configuration.Jobs.TryGetValue(jobName, out var job);
+                if (job != null)
+                {
+                    foreach (var variable in job.Variables)
+                    {
+                        jobResult.Variables.Add(variable.Key, variable.Value);
+                    }
+                }
 
                 foreach (var jobConnection in jobConnections)
                 {

--- a/src/Microsoft.Crank.Models/JobResults.cs
+++ b/src/Microsoft.Crank.Models/JobResults.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Crank.Models
         public Dependency[] Dependencies { get; set; } = Array.Empty<Dependency>();
         public List<Measurement[]> Measurements { get; set; } = new List<Measurement[]>();
         public Dictionary<string, object> Environment { get; set; } = new Dictionary<string, object>();
+
+        public Dictionary<string, object> Variables { get; set; } = new Dictionary<string, object>();
         public Benchmark[] Benchmarks { get; set; } = Array.Empty<Benchmark>();
     }
 


### PR DESCRIPTION
Close #566 

1. Add **Variables** in class `JobResult`
2. Set **Variables** from `Configuration.Jobs.Variables` when creating job results
3. Add **Variables** for CSV result


Json result:

![image](https://user-images.githubusercontent.com/8394988/230933467-1e790475-dc9e-4362-8332-a4f95c69e6ca.png)

CSV result:

![image](https://user-images.githubusercontent.com/8394988/230936347-1fc5ffd6-18c5-4818-b8a3-df3cfd9ea212.png)
