### PR TITLE
Use % format for GC Heap Fragmentation

### DIFF
--- a/src/Microsoft.Crank.Controller/default.config.yml
+++ b/src/Microsoft.Crank.Controller/default.config.yml
@@ -419,8 +419,8 @@ results: # creates results from measurements
 
 - name: runtime-counter/gc-fragmentation
   measurement: runtime-counter/gc-fragmentation
-  description: Max GC Heap Fragmentation
-  format: n0
+  description: Max GC Heap Fragmentation (%)
+  format: p0
   aggregate: max
   reduce: max
 


### PR DESCRIPTION
Values are between [0-1] and represent a percentage. This currently displays `0` as formatted with `n0`. With `p0` this will show up as `36%`. 

NB: There is another counter that returns percentages (Max Time in GC), but this one returns values in [0-100] range.