### PR TITLE
Update dotnet versions

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
   "tools": {
     "dotnet": "7.0.306"
-    }
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.23370.3"

--- a/global.json
+++ b/global.json
@@ -1,13 +1,6 @@
 {
   "tools": {
-    "dotnet": "7.0.306",
-    "runtimes": {
-      "dotnet": [
-        "7.0.9"
-      ],
-      "aspnetcore": [
-        "7.0.9"
-      ]
+    "dotnet": "7.0.306"
     }
   },
   "msbuild-sdks": {

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "tools": {
-    "dotnet": "8.0.100-preview.6.23330.14",
+    "dotnet": "7.0.306",
     "runtimes": {
       "dotnet": [
-        "7.0.1"
+        "7.0.9"
       ],
       "aspnetcore": [
-        "7.0.1"
+        "7.0.9"
       ]
     }
   },


### PR DESCRIPTION
Attempting to fix this signing validation error:

```
D:\a\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\7.0.0-beta.23370.3\tools\SdkTasks\SigningValidation.proj : error : Version 8.0.100-preview.6.23330.14 of the .NET SDK requires at least version 17.6.0 of MSBuild. The current available version of MSBuild is 17.4.0.51802. Change the .NET SDK specified in global.json to an older version that requires the MSBuild version currently available.
D:\a\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\7.0.0-beta.23370.3\tools\SdkTasks\SigningValidation.proj : error : The NuGetSdkResolver did not resolve this SDK because there was no version specified in the project or global.json.
D:\a\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\7.0.0-beta.23370.3\tools\SdkTasks\SigningValidation.proj : error MSB4236: The SDK 'Microsoft.NET.Sdk' specified could not be found.

```