### PR TITLE
Ensure empty arguments are encoded as double quotes (correctly)

### DIFF
--- a/src/Microsoft.Crank.Controller/Program.cs
+++ b/src/Microsoft.Crank.Controller/Program.cs
@@ -3228,7 +3228,7 @@ namespace Microsoft.Crank.Controller
 
             if (string.IsNullOrEmpty(original))
             {
-                return original;
+                return "";
             }
 
             var value = Regex.Replace(original, @"(\\*)" + "\"", @"$1\$0");

--- a/src/Microsoft.Crank.Controller/Program.cs
+++ b/src/Microsoft.Crank.Controller/Program.cs
@@ -3228,7 +3228,7 @@ namespace Microsoft.Crank.Controller
 
             if (string.IsNullOrEmpty(original))
             {
-                return "";
+                return "\"\"";
             }
 
             var value = Regex.Replace(original, @"(\\*)" + "\"", @"$1\$0");


### PR DESCRIPTION
Actually fixes #628.

I completely missed that I forgot to put the actual double quotes in. Tested this time and it's working.