### PR TITLE
Improve CTRL+C reliability

### DIFF
--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -1606,7 +1606,7 @@ namespace Microsoft.Crank.Agent
                                     {
                                         if (!process.HasExited)
                                         {
-                                            Log.Info($"Sending CTRL+C ...");
+                                            Log.Info("Sending CTRL+C ...");
 
                                             SendCtrlCSignalToProcess(process);
                                         }
@@ -1626,7 +1626,7 @@ namespace Microsoft.Crank.Agent
 
                                                 do
                                                 {
-                                                    Log.Info($"Shutdown successfully invoked, waiting for graceful shutdown ...");
+                                                    Log.Info("Shutdown successfully invoked, waiting for graceful shutdown ...");
                                                     await Task.Delay(1000);
 
                                                 } while (!process.HasExited && (DateTime.UtcNow - epoch < TimeSpan.FromSeconds(5)));
@@ -5814,11 +5814,11 @@ namespace Microsoft.Crank.Agent
                             // Wait for the process to finish (give it up to 20 seconds)
                             if (process.WaitForExit(20000))
                             {
-                                Log.Info($"Process has exited");
+                                Log.Info("Process has exited");
                             }
                             else
                             {
-                                Log.Info($"Process did not exit from the CTRL+C");
+                                Log.Info("Process did not exit from the CTRL+C");
                             }
                         }
                         finally
@@ -5829,7 +5829,7 @@ namespace Microsoft.Crank.Agent
                     }
                     else
                     {
-                        Log.Info($"Skipping signal since process has already exited");
+                        Log.Info("Skipping signal since process has already exited");
                     }
                 }
             }

--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -5818,10 +5818,13 @@ namespace Microsoft.Crank.Agent
                         try
                         {
                             // Generate console event for current console with GenerateConsoleCtrlEvent (processGroupId should be zero)
-                            GenerateConsoleCtrlEvent(signal, (uint)process.Id);
+                            GenerateConsoleCtrlEvent(signal, 0);
 
                             // Wait for the process to finish (give it up to 20 seconds)
-                            process.WaitForExit(20000);
+                            if (process.WaitForExit(20000))
+                            {
+                                Log.Info($"Process has exited");
+                            }
                         }
                         finally
                         {

--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -5818,7 +5818,7 @@ namespace Microsoft.Crank.Agent
                         try
                         {
                             // Generate console event for current console with GenerateConsoleCtrlEvent (processGroupId should be zero)
-                            GenerateConsoleCtrlEvent(signal, 0);
+                            GenerateConsoleCtrlEvent(signal, (uint)process.Id);
 
                             // Wait for the process to finish (give it up to 20 seconds)
                             process.WaitForExit(20000);

--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -34,14 +34,12 @@ using Microsoft.Diagnostics.Tools.Trace;
 using Microsoft.Diagnostics.Tracing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuGet.Versioning;
 using Repository;
 using Serilog;
 using Serilog.Events;
-using Serilog.Filters;
 using Serilog.Sinks.SystemConsole.Themes;
 using Vanara.PInvoke;
 using OperatingSystem = Microsoft.Crank.Models.OperatingSystem;
@@ -5861,12 +5859,6 @@ namespace Microsoft.Crank.Agent
         [DllImport("kernel32.dll", SetLastError = true)]
         private static extern bool GenerateConsoleCtrlEvent(CtrlTypes dwCtrlEvent, uint dwProcessGroupId);
 
-        [DllImport("kernel32.dll", SetLastError = true)]
-        private static extern bool AttachConsole(uint dwProcessId);
-
-        [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
-        private static extern bool FreeConsole();
-
         [DllImport("Kernel32", SetLastError = true)]
         private static extern bool SetConsoleCtrlHandler(HandlerRoutine handler, bool add);
 
@@ -5875,10 +5867,6 @@ namespace Microsoft.Crank.Agent
         enum CtrlTypes
         {
             CTRL_C_EVENT = 0,
-            CTRL_BREAK_EVENT = 1,
-            CTRL_CLOSE_EVENT,
-            CTRL_LOGOFF_EVENT = 5,
-            CTRL_SHUTDOWN_EVENT
         }
 
         /// <param name="providers">


### PR DESCRIPTION
Noticed the CTRL+C was exiting its boundaries sometimes and killing the Agent too. This is restoring the CTRL handlers in a finally block and changing the handler group to 0.
