### PR TITLE
Don't override default Thread_AssignCpuGroups value

### DIFF
--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -4660,7 +4660,6 @@ namespace Microsoft.Crank.Agent
                 if (!String.IsNullOrWhiteSpace(job.CpuSet) && job.CpuLimitRatio == 0)
                 {
                     process.StartInfo.EnvironmentVariables.Add("DOTNET_PROCESSOR_COUNT", CalculateCpuList(job.CpuSet).Count.ToString(CultureInfo.InvariantCulture));
-                    process.StartInfo.EnvironmentVariables.Add("DOTNET_Thread_AssignCpuGroups", "0");
                 }
             }
 


### PR DESCRIPTION
This is the responsibility of the benchmark