### PR TITLE
Call Microsoft.Crank.JobObjectWrapper.exe with full path 

### DIFF
--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -4653,7 +4653,7 @@ namespace Microsoft.Crank.Agent
                 var arguments = process.StartInfo.Arguments;
 
                 // The executable should be in the same folder as the agent since it references the Console project
-                process.StartInfo.FileName = "Microsoft.Crank.JobObjectWrapper.exe";
+                process.StartInfo.FileName = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Microsoft.Crank.JobObjectWrapper.exe");
                 process.StartInfo.Arguments = filename + " " + arguments;
 
                 // .NET doesn't respect a cpu affinity if a ratio is not set too. https://github.com/dotnet/runtime/issues/94364

--- a/src/Microsoft.Crank.JobOjectWrapper/Program.cs
+++ b/src/Microsoft.Crank.JobOjectWrapper/Program.cs
@@ -30,8 +30,26 @@ Console.WriteLine("Starting process...");
 Console.WriteLine($"Filename: {process.StartInfo.FileName}");
 Console.WriteLine($"Args: {process.StartInfo.Arguments}");
 
+process.OutputDataReceived += (_, e) =>
+{
+    if (e != null && e.Data != null)
+    {
+        Console.WriteLine(e.Data);
+    }
+};
+
+process.ErrorDataReceived += (_, e) =>
+{
+    if (e != null && e.Data != null)
+    {
+        Console.WriteLine(e.Data);
+    }
+};
+
 process.Start();
 Console.WriteLine($"##ChildProcessId:{process.Id}");
+process.BeginOutputReadLine();
+process.BeginErrorReadLine();
 process.WaitForExit();
 
 Console.WriteLine(process.StandardOutput.ReadToEnd());

--- a/src/Microsoft.Crank.JobOjectWrapper/Program.cs
+++ b/src/Microsoft.Crank.JobOjectWrapper/Program.cs
@@ -20,9 +20,7 @@ var process = new Process()
     StartInfo = {
         FileName = args[0],
         Arguments = string.Join(" ", args[1..]),
-        UseShellExecute = false,
-        RedirectStandardOutput = true,
-        RedirectStandardError = true,
+        UseShellExecute = false
     }
 };
 
@@ -30,28 +28,8 @@ Console.WriteLine("Starting process...");
 Console.WriteLine($"Filename: {process.StartInfo.FileName}");
 Console.WriteLine($"Args: {process.StartInfo.Arguments}");
 
-process.OutputDataReceived += (_, e) =>
-{
-    if (e != null && e.Data != null)
-    {
-        Console.WriteLine(e.Data);
-    }
-};
-
-process.ErrorDataReceived += (_, e) =>
-{
-    if (e != null && e.Data != null)
-    {
-        Console.WriteLine(e.Data);
-    }
-};
-
 process.Start();
 Console.WriteLine($"##ChildProcessId:{process.Id}");
-process.BeginOutputReadLine();
-process.BeginErrorReadLine();
 process.WaitForExit();
-
-Console.WriteLine(process.StandardOutput.ReadToEnd());
 
 await Task.Delay(1000);

--- a/test/Microsoft.Crank.IntegrationTests/CommonTests.cs
+++ b/test/Microsoft.Crank.IntegrationTests/CommonTests.cs
@@ -371,6 +371,29 @@ namespace Microsoft.Crank.IntegrationTests
             Assert.Contains("--header \"x-header: demo\"", agentLog);
         }
 
+        [Fact]
+        public async Task BenchmarkHelloWithCpuSetSingleCore()
+        {
+            _output.WriteLine($"[TEST] Starting controller");
+
+            var result = await ProcessUtil.RunAsync(
+                "dotnet",
+                $"exec {Path.Combine(_crankDirectory, "crank.dll")} --config ./assets/hello.benchmarks.yml --scenario hello --profile local --application.cpuSet 0",
+                workingDirectory: _crankTestsDirectory,
+                captureOutput: true,
+                timeout: DefaultTimeOut,
+                throwOnError: false,
+                outputDataReceived: t => { _output.WriteLine($"[CTL] {t}"); }
+            );
+
+            Assert.Equal(0, result.ExitCode);
+
+            Assert.Contains("Requests/sec", result.StandardOutput);
+            Assert.Contains(".NET Core SDK Version", result.StandardOutput);
+            Assert.Contains(".NET Runtime Version", result.StandardOutput);
+            Assert.Contains("ASP.NET Core Version", result.StandardOutput);
+        }
+
         public void Dispose()
         {
             _output.WriteLine(_agent.FlushOutput());

--- a/test/Microsoft.Crank.IntegrationTests/CommonTests.cs
+++ b/test/Microsoft.Crank.IntegrationTests/CommonTests.cs
@@ -371,7 +371,7 @@ namespace Microsoft.Crank.IntegrationTests
             Assert.Contains("--header \"x-header: demo\"", agentLog);
         }
 
-        [Fact]
+        [SkipOnLinux]
         public async Task BenchmarkHelloWithCpuSetSingleCore()
         {
             _output.WriteLine($"[TEST] Starting controller");

--- a/test/Microsoft.Crank.IntegrationTests/SkipOnLinuxAttribute.cs
+++ b/test/Microsoft.Crank.IntegrationTests/SkipOnLinuxAttribute.cs
@@ -1,0 +1,16 @@
+﻿using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Microsoft.Crank.IntegrationTests
+{
+    class SkipOnLinuxAttribute : FactAttribute
+    {
+        public SkipOnLinuxAttribute(string message = null) 
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                Skip = message ?? "Test ignored on Linux";
+            }
+        }
+    }
+}


### PR DESCRIPTION
Instead of relying on starting in the correct working directory, specify that we want the Microsoft.Crank.JobObjectWrapper.exe in the same location of the assembly/tool.