### PR TITLE
Updating target framework for hello sample

### DIFF
--- a/samples/hello/hello.benchmarks.yml
+++ b/samples/hello/hello.benchmarks.yml
@@ -4,8 +4,8 @@ imports:
 jobs:
   server:
     source:
-      repository: https://github.com/dotnet/crank
-      branchOrCommit: main
+      repository: https://github.com/ks1990cn/crank
+      branchOrCommit: updateSampleVersion
       project: samples/hello/hello.csproj
     readyStateText: Application started.
 

--- a/samples/hello/hello.benchmarks.yml
+++ b/samples/hello/hello.benchmarks.yml
@@ -4,8 +4,8 @@ imports:
 jobs:
   server:
     source:
-      repository: https://github.com/ks1990cn/crank
-      branchOrCommit: updateSampleVersion
+      repository: https://github.com/dotnet/crank
+      branchOrCommit: main
       project: samples/hello/hello.csproj
     readyStateText: Application started.
 

--- a/samples/hello/hello.csproj
+++ b/samples/hello/hello.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/samples/hello/hello.csproj
+++ b/samples/hello/hello.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Closes #682 

Updating new target framework for sample project 3.1 is outdated now.

Impact may not be so much technically but if someone have to learn from this tutorial https://www.youtube.com/watch?v=2IgfrnG-128&t=692s , there will be no need for 3.1 (outdated version) to be added in system anymore.