### PR TITLE
Use SetProcessAffinityMask instead of SetProcessDefaultCpuSets

### DIFF
--- a/src/Microsoft.Crank.JobOjectWrapper/Program.cs
+++ b/src/Microsoft.Crank.JobOjectWrapper/Program.cs
@@ -10,10 +10,11 @@ if (args.Length == 0)
     Environment.Exit(-1);
 }
 
+var time = 1000;
 Console.WriteLine("Job Object Wrapper");
-Console.WriteLine("Waiting for Job Object to be setup...");
+Console.WriteLine($"Waiting for Job Object to be setup... {time}");
 
-await Task.Delay(1000);
+await Task.Delay(time);
 
 var process = new Process()
 {


### PR DESCRIPTION
`JobObjectWrapper` is not necessary anymore, tested locally. We might still benefit from using a SUSPENDED thread once the API is available in the runtime.
`Environment.ProcessorCount` is also returning the correct value, and overriding its value is not necesary anymore.
