### PR TITLE
Track more latencies in K6

### DIFF
--- a/src/Microsoft.Crank.Jobs.K6/Program.cs
+++ b/src/Microsoft.Crank.Jobs.K6/Program.cs
@@ -190,8 +190,10 @@ namespace Microsoft.Crank.Jobs.K6
             BenchmarksEventSource.Register("http/requests/badresponses", Operations.Max, Operations.Sum, "Bad responses", "Non-2xx or 3xx responses", "n0");
 
             BenchmarksEventSource.Register("http/latency/50", Operations.Max, Operations.Max, "Latency 50th (ms)", "Latency 50th (ms)", "n2");
+            BenchmarksEventSource.Register("http/latency/75", Operations.Max, Operations.Max, "Latency 75th (ms)", "Latency 75th (ms)", "n2");
             BenchmarksEventSource.Register("http/latency/90", Operations.Max, Operations.Max, "Latency 90th (ms)", "Latency 90th (ms)", "n2");
             BenchmarksEventSource.Register("http/latency/95", Operations.Max, Operations.Max, "Latency 95th (ms)", "Latency 95th (ms)", "n2");
+            BenchmarksEventSource.Register("http/latency/99", Operations.Max, Operations.Max, "Latency 99th (ms)", "Latency 99th (ms)", "n2");
 
             BenchmarksEventSource.Register("http/latency/mean", Operations.Max, Operations.Avg, "Mean latency (ms)", "Mean latency (ms)", "n2");
             BenchmarksEventSource.Register("http/latency/max", Operations.Max, Operations.Max, "Max latency (ms)", "Max latency (ms)", "n2");
@@ -211,10 +213,12 @@ namespace Microsoft.Crank.Jobs.K6
             BenchmarksEventSource.Measure("http/requests/badresponses", reqFailed.GetProperty("values").GetProperty("passes").GetInt64());
 
             var reqDurationValues = metrics.GetProperty("http_req_duration").GetProperty("values");
-            
-            BenchmarksEventSource.Measure("http/latency/50", reqDurationValues.GetProperty("med").GetDouble());
+
+            BenchmarksEventSource.Measure("http/latency/50", reqDurationValues.GetProperty("p(50)").GetDouble());
+            BenchmarksEventSource.Measure("http/latency/75", reqDurationValues.GetProperty("p(75)").GetDouble());
             BenchmarksEventSource.Measure("http/latency/90", reqDurationValues.GetProperty("p(90)").GetDouble());
             BenchmarksEventSource.Measure("http/latency/95", reqDurationValues.GetProperty("p(95)").GetDouble());
+            BenchmarksEventSource.Measure("http/latency/99", reqDurationValues.GetProperty("p(99)").GetDouble());
 
             BenchmarksEventSource.Measure("http/latency/mean", reqDurationValues.GetProperty("avg").GetDouble());
             BenchmarksEventSource.Measure("http/latency/max", reqDurationValues.GetProperty("max").GetDouble());

--- a/src/Microsoft.Crank.Jobs.K6/scripts/default.js
+++ b/src/Microsoft.Crank.Jobs.K6/scripts/default.js
@@ -5,6 +5,7 @@ const url = __ENV.URL;
 const presetHeaders = __ENV.HEADERS
 
 export const options = {
+    summaryTrendStats: ['avg', 'min', 'max', 'p(50)', 'p(75)', 'p(90)', 'p(95)', 'p(99)']
 };
 
 export default function () {


### PR DESCRIPTION
Results:

```
| load                    |                    |
| ----------------------- | ------------------ |
| Max CPU Usage (%)       | 12                 |
| Max Cores usage (%)     | 348                |
| Max Working Set (MB)    | 209                |
| Max Private Memory (MB) | 236                |
| Build Time (ms)         | 3,340              |
| Start Time (ms)         | 85                 |
| Published Size (KB)     | 72,944             |
| Symbols Size (KB)       | 0                  |
| .NET Core SDK Version   | 8.0.101            |
| ASP.NET Core Version    | 8.0.1+8e941eb42f81 |
| .NET Runtime Version    | 8.0.1+bf5e279d9239 |
| First Request (ms)      | 109                |
| Requests                | 70,513             |
| Bad responses           | 0                  |
| Latency 50th (ms)       | 0.18               |
| Latency 75th (ms)       | 0.22               |
| Latency 90th (ms)       | 0.27               |
| Latency 95th (ms)       | 0.30               |
| Latency 99th (ms)       | 0.48               |
| Mean latency (ms)       | 0.23               |
| Max latency (ms)        | 20.87              |
| Requests/sec            | 10,000             |
| Read throughput (MB/s)  | 1.39               |
```