### PR TITLE
Added the Startup Event to the Benchmarks Event Source

### DIFF
--- a/src/Microsoft.Crank.Agent/Microsoft.Crank.Agent.csproj
+++ b/src/Microsoft.Crank.Agent/Microsoft.Crank.Agent.csproj
@@ -41,6 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Crank.EventSources\Microsoft.Crank.EventSources.csproj" />
     <ProjectReference Include="..\Microsoft.Crank.JobOjectWrapper\Microsoft.Crank.JobObjectWrapper.csproj" />
     <ProjectReference Include="..\Microsoft.Crank.Models\Microsoft.Crank.Models.csproj" />
   </ItemGroup>

--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -5324,14 +5324,12 @@ namespace Microsoft.Crank.Agent
 
             job.StartupMainMethod = stopwatch.Elapsed;
 
-            var startupMeasurement = new Measurement
+            job.Measurements.Enqueue(new Measurement
             {
                 Name = Measurements.BenchmarksStartTime,
                 Timestamp = DateTime.UtcNow,
                 Value = stopwatch.ElapsedMilliseconds
-            };
-
-            job.Measurements.Enqueue(startupMeasurement);
+            });
             BenchmarksEventSource.Start();
 
             Log.Info($"Running job '{job.Service}' ({job.Id})");

--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -28,6 +28,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.WindowsServices;
 using Microsoft.Azure.Relay;
+using Microsoft.Crank.EventSources;
 using Microsoft.Crank.Models;
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tools.Trace;
@@ -5323,12 +5324,15 @@ namespace Microsoft.Crank.Agent
 
             job.StartupMainMethod = stopwatch.Elapsed;
 
-            job.Measurements.Enqueue(new Measurement
+            var startupMeasurement = new Measurement
             {
                 Name = Measurements.BenchmarksStartTime,
                 Timestamp = DateTime.UtcNow,
                 Value = stopwatch.ElapsedMilliseconds
-            });
+            };
+
+            job.Measurements.Enqueue(startupMeasurement);
+            BenchmarksEventSource.Start();
 
             Log.Info($"Running job '{job.Service}' ({job.Id})");
             job.Url = ComputeServerUrl(hostname, job);

--- a/src/Microsoft.Crank.EventSources/BenchmarksEventSource.cs
+++ b/src/Microsoft.Crank.EventSources/BenchmarksEventSource.cs
@@ -110,6 +110,11 @@ namespace Microsoft.Crank.EventSources
             }
         }
 
+        public static void Start()
+        {
+            Log.Started();
+        }
+
         [Event(1, Level = EventLevel.Informational)]
         public void MeasureLong(string name, long value)
         {
@@ -132,6 +137,12 @@ namespace Microsoft.Crank.EventSources
         public void Metadata(string name, string aggregate, string reduce, string shortDescription, string longDescription, string format)
         {
             WriteEvent(5, name, aggregate, reduce, shortDescription, longDescription, format);
+        }
+
+        [Event(6, Level = EventLevel.Informational)]
+        public void Started()
+        {
+            WriteEvent(6);
         }
     }
 }


### PR DESCRIPTION
Related to: https://github.com/aspnet/Benchmarks/pull/1862#issuecomment-1925110806

- Added the startup event as a part of the Benchmarks event source.
- Tested with the hello scenario using the following command: ```crank --config /crank/samples/local/local.benchmarks.yml --scenario hello --profile local --application.collect true --application.collectArguments "Providers=Benchmarks"``` 
- Observed the event showing up in the Events View in PerfView:

![image](https://github.com/dotnet/crank/assets/68247673/0a6c7537-f777-422f-844b-b9e2c2fc07f3)

Please let me know if there is a better way to accomplish this. 