### PR TITLE
Revert jobs to use source instead of sources

### DIFF
--- a/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
+++ b/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
@@ -9,14 +9,12 @@
 
 jobs:
   bombardier:
-    sources:
-      crank:
-        repository: https://github.com/dotnet/crank.git
-        branchOrCommit: main
-        sourceKey: bombardier
-        destinationFolder: ''
-    project: src/Microsoft.Crank.Jobs.Bombardier/Microsoft.Crank.Jobs.Bombardier.csproj
-    noBuild: true
+    source:
+      repository: https://github.com/dotnet/crank.git
+      branchOrCommit: main
+      project: src/Microsoft.Crank.Jobs.Bombardier/Microsoft.Crank.Jobs.Bombardier.csproj
+      sourceKey: bombardier
+      noBuild: true
     readyStateText: Bombardier Client
     waitForExit: true
     variables:

--- a/src/Microsoft.Crank.Jobs.H2Load/h2load.yml
+++ b/src/Microsoft.Crank.Jobs.H2Load/h2load.yml
@@ -7,14 +7,12 @@
 
 jobs:
   h2LoadClient:
-    sources:
-      crank:
-        repository: https://github.com/dotnet/crank.git
-        branchOrCommit: main
-        sourceKey: h2load
-        destinationFolder: ''
-    project: src/Microsoft.Crank.Jobs.H2Load/Microsoft.Crank.Jobs.H2Load.csproj
-    noBuild: true
+    source:
+      repository: https://github.com/dotnet/crank.git
+      branchOrCommit: main
+      project: src/Microsoft.Crank.Jobs.H2Load/Microsoft.Crank.Jobs.H2Load.csproj
+      sourceKey: h2load
+      noBuild: true
     readyStateText: H2Load Client
     waitForExit: true
     variables:

--- a/src/Microsoft.Crank.Jobs.HttpClient/httpclient.yml
+++ b/src/Microsoft.Crank.Jobs.HttpClient/httpclient.yml
@@ -9,12 +9,10 @@
 
 jobs:
   httpclient:
-    sources:
-      crank:
-        repository: https://github.com/dotnet/crank.git
-        branchOrCommit: main
-        destinationFolder: ''
-    project: src/Microsoft.Crank.Jobs.HttpClient/Microsoft.Crank.Jobs.HttpClient.csproj
+    source:
+      repository: https://github.com/dotnet/crank.git
+      branchOrCommit: main
+      project: src/Microsoft.Crank.Jobs.HttpClient/Microsoft.Crank.Jobs.HttpClient.csproj
     readyStateText: Http Client
     isConsoleApp: true
     waitForExit: true

--- a/src/Microsoft.Crank.Jobs.K6/k6.yml
+++ b/src/Microsoft.Crank.Jobs.K6/k6.yml
@@ -1,13 +1,11 @@
 ﻿jobs:
   k6:
-    sources:
-      crank:
-        repository: https://github.com/dotnet/crank.git
-        branchOrCommit: main
-        sourceKey: k6
-        destinationFolder: ''
-    project: src/Microsoft.Crank.Jobs.K6/Microsoft.Crank.Jobs.K6.csproj
-    noBuild: true
+    source:
+      repository: https://github.com/dotnet/crank.git
+      branchOrCommit: main
+      project: src/Microsoft.Crank.Jobs.K6/Microsoft.Crank.Jobs.K6.csproj
+      sourceKey: k6
+      noBuild: true
     readyStateText: K6 Client
     waitForExit: true
     variables:

--- a/src/Microsoft.Crank.Jobs.PipeliningClient/pipelining.yml
+++ b/src/Microsoft.Crank.Jobs.PipeliningClient/pipelining.yml
@@ -9,12 +9,10 @@
 
 jobs:
   pipelining:
-    sources:
-      crank:
-        repository: https://github.com/dotnet/crank.git
-        branchOrCommit: main
-        destinationFolder: ''
-    project: src/Microsoft.Crank.Jobs.PipeliningClient/Microsoft.Crank.Jobs.PipeliningClient.csproj
+    source:
+      repository: https://github.com/dotnet/crank.git
+      branchOrCommit: main
+      project: src/Microsoft.Crank.Jobs.PipeliningClient/Microsoft.Crank.Jobs.PipeliningClient.csproj
     readyStateText: Pipelining Client
     isConsoleApp: true
     waitForExit: true

--- a/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
+++ b/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
@@ -9,14 +9,12 @@
 
 jobs:
   wrk:
-    sources:
-      crank:
-        repository: https://github.com/dotnet/crank.git
-        branchOrCommit: main
-        sourceKey: wrk
-        destinationFolder: ''
-    project: src/Microsoft.Crank.Jobs.Wrk/Microsoft.Crank.Jobs.Wrk.csproj
-    noBuild: true
+    source:
+      repository: https://github.com/dotnet/crank.git
+      branchOrCommit: main
+      project: src/Microsoft.Crank.Jobs.Wrk/Microsoft.Crank.Jobs.Wrk.csproj
+      sourceKey: wrk
+      noBuild: true
     isConsoleApp: true
     waitForExit: true
     variables:

--- a/src/Microsoft.Crank.Jobs.Wrk2/wrk2.yml
+++ b/src/Microsoft.Crank.Jobs.Wrk2/wrk2.yml
@@ -12,12 +12,10 @@ variables:
 
 jobs:
   wrk2:
-    sources:
-      crank:
-        repository: https://github.com/dotnet/crank.git
-        branchOrCommit: main
-        destinationFolder: ''
-    project: src/Microsoft.Crank.Jobs.Wrk2/Microsoft.Crank.Jobs.Wrk2.csproj
+    source:
+      repository: https://github.com/dotnet/crank.git
+      branchOrCommit: main
+      project: src/Microsoft.Crank.Jobs.Wrk2/Microsoft.Crank.Jobs.Wrk2.csproj
     isConsoleApp: true
     waitForExit: true
     variables:


### PR DESCRIPTION
Reverts the jobs that are defined inside this repo to use `source` instead of `sources`. In my recent change ([link](https://github.com/dotnet/crank/commit/ec795589deff97bac339962928499fe4446986b0?diff=unified&w=0)), I made it so that all the jobs such as wrk, bombardier, wrk2 etc. used `sources` instead of `source`. This commit also included a bug fix which is required for this change to work or it would throw an error. Anyone using a crank controller which does not have the bug fix yet will get the following error:

    $ crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/plaintext.benchmarks.yml --scenario plaintext --profile aspnet-perf-lin
    The service 'load' is missing some properties to start the job.
    Check that any of these properties is set: project, executable, dockerFile, dockerLoad, dockerPull

This PR temporarily reverts the jobs to use `source` instead of `sources` until we are confident that anyone using crank has installed the latest version which has the bug fix.