### PR TITLE
1ES Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,17 +24,28 @@ trigger:
     - main
     - release/*
 
-pr:
-  autoCancel: true
-  branches:
-    include:
-    - '*'
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  parameters:
+    sdl:
+      sourceAnalysisPool:
+        name: $(DncEngInternalBuildPool)
+        image: 1es-windows-2022-pt
+        os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
 
 stages:
 - stage: build
   displayName: Build
   jobs:
-  - template: /eng/common/templates/jobs/jobs.yml
+  - template: /eng/common/templates-official/jobs/jobs.yml
     parameters:
       enableMicrobuild: true
       enablePublishBuildArtifacts: true
@@ -44,35 +55,22 @@ stages:
       enableTelemetry: true
       mergeTestResults: true
       jobs:
-      # - ${{ if and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - job: Windows
         pool:
-          ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            name: NetCore-Public
-            demands: ImageOverride -equals windows.vs2022.amd64.open
-          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals windows.vs2022.amd64
+          name: $(DncEngInternalBuildPool)
+          image: 1es-windows-2022-pt
+          os: windows
         variables:
           
-
-        # Only enable publishing in official builds.
-        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-          - group: Publish-Build-Assets
-          - name: _OfficialBuildArgs
-            value: /p:DotNetSignType=$(_SignType)
-                  /p:TeamName=$(_TeamName)
-                  /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
-                  /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-          - name: _SignType
-            value: real
-        # else
-        - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-          - name: _OfficialBuildArgs
-            value: ''
-          - name: _SignType
-            value: test
+        # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
+        - group: Publish-Build-Assets
+        - name: _OfficialBuildArgs
+          value: /p:DotNetSignType=$(_SignType)
+                /p:TeamName=$(_TeamName)
+                /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+                /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+        - name: _SignType
+          value: real
                 
         steps:
         - checkout: self
@@ -97,69 +95,8 @@ stages:
             artifactType: Container
             parallel: true
 
-      - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-        - job: Ubuntu
-          displayName: 'Ubuntu 20.04'
-          pool:
-            vmImage: ubuntu-latest
-          variables:
-          - name: _SignType
-            value: none
-          - name: _OfficialBuildArgs
-            value: ''
-
-          steps:
-          - checkout: self
-            clean: true
-          - script: eng/common/cibuild.sh
-              --configuration $(_BuildConfig)
-              --prepareMachine
-            displayName: Build
-          - task: PublishBuildArtifacts@1
-            displayName: Upload TestResults
-            condition: always()
-            continueOnError: true
-            inputs:
-              pathtoPublish: artifacts/TestResults/$(_BuildConfig)/
-              artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
-              artifactType: Container
-              parallel: true
-      
-      # Tests on macOS are unreliable
-      # - job: macOS
-      #   displayName: 'macOS 10.15'
-      #   pool:
-      #     vmImage: macOS-1015
-      #   variables:
-      #   - name: _SignType
-      #     value: none
-
-      #   - ${{ if and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      #     - name: _OfficialBuildArgs
-      #       value: -p:OfficialBuildId=$(Build.BuildNumber)
-      #   # else
-      #   - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-      #     - name: _OfficialBuildArgs
-      #       value: ''
-      #   steps:
-      #   - checkout: self
-      #     clean: true
-      #   - script: eng/common/cibuild.sh
-      #       --configuration $(_BuildConfig)
-      #       --prepareMachine
-      #     displayName: Build
-      #   - task: PublishBuildArtifacts@1
-      #     displayName: Upload TestResults
-      #     condition: always()
-      #     continueOnError: true
-      #     inputs:
-      #       pathtoPublish: artifacts/TestResults/$(_BuildConfig)/
-      #       artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
-      #       artifactType: Container
-      #       parallel: true
-
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: eng\common\templates\post-build\post-build.yml
+  - template: eng\common\templates-official\post-build\post-build.yml
     parameters:
       # Symbol validation isn't being very reliable lately. This should be enabled back
       # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ extends:
           enableMicrobuild: true
           enablePublishBuildArtifacts: true
           enablePublishTestResults: true
-          enablePublishBuildAssets: false
+          enablePublishBuildAssets: true
           enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
           enableTelemetry: true
           mergeTestResults: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,6 @@ extends:
               clean: true
             - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_OfficialBuildArgs)
               displayName: Build and Publish
-<<<<<<< HEAD
             # - task: PublishBuildArtifacts@1
             #   displayName: Upload TestResults
             #   condition: always()
@@ -102,21 +101,6 @@ extends:
                 ArtifactType: Container
                 Parallel: true
               - output: buildArtifacts
-=======
-            - task: PublishBuildArtifacts@1
-              displayName: Upload TestResults
-              condition: always()
-              continueOnError: true
-              inputs:
-                pathtoPublish: artifacts/TestResults/$(_BuildConfig)/
-                artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
-                artifactType: Container
-                parallel: true
-            - task: PublishBuildArtifacts@1
-              displayName: Upload package artifacts
-              condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
-              inputs:
->>>>>>> 7ca9507 (Fix indenting)
                 pathtoPublish: artifacts/packages/
                 artifactName: artifacts
                 artifactType: Container
@@ -124,10 +108,14 @@ extends:
 
 
 <<<<<<< HEAD
+<<<<<<< HEAD
     - template: eng\common\templates-official\post-build\post-build.yml@self
 =======
     - template: eng\common\templates-official\post-build\post-build.yml
 >>>>>>> 7ca9507 (Fix indenting)
+=======
+    - template: eng\common\templates-official\post-build\post-build.yml@self
+>>>>>>> 49f745f (Add @self decorators)
       parameters:
         # Symbol validation isn't being very reliable lately. This should be enabled back
         # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,6 +105,7 @@ stages:
       # It's a private repo in github so this won't pass until we create an internal mirror
       enableSourceLinkValidation: false
       publishingInfraVersion: 3
+      publishAssetsImmediately: true
       # This is to enable SDL runs part of Post-Build Validation Stage
       SDLValidationParameters:
         enable: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,19 +77,31 @@ extends:
               clean: true
             - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_OfficialBuildArgs)
               displayName: Build and Publish
-            - task: PublishBuildArtifacts@1
-              displayName: Upload TestResults
-              condition: always()
-              continueOnError: true
-              inputs:
-                pathtoPublish: artifacts/TestResults/$(_BuildConfig)/
-                artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
-                artifactType: Container
-                parallel: true
-            - task: PublishBuildArtifacts@1
-              displayName: Upload package artifacts
-              condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
-              inputs:
+            # - task: PublishBuildArtifacts@1
+            #   displayName: Upload TestResults
+            #   condition: always()
+            #   continueOnError: true
+            #   inputs:
+            #     pathtoPublish: artifacts/TestResults/$(_BuildConfig)/
+            #     artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
+            #     artifactType: Container
+            #     parallel: true
+            # - task: PublishBuildArtifacts@1
+            #   displayName: Upload package artifacts
+            #   condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+            #   inputs:
+            #     pathtoPublish: artifacts/packages/
+            #     artifactName: artifacts
+            #     artifactType: Container
+            #     parallel: true
+            templateContext:
+              outputs:
+              - output: buildArtifacts
+                PathtoPublish: artifacts/TestResults/$(_BuildConfig)/
+                ArtifactName: $(Agent.Os)_$(Agent.JobName) TestResults
+                ArtifactType: Container
+                Parallel: true
+              - output: buildArtifacts
                 pathtoPublish: artifacts/packages/
                 artifactName: artifacts
                 artifactType: Container

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,6 +76,7 @@ extends:
               clean: true
             - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_OfficialBuildArgs)
               displayName: Build and Publish
+<<<<<<< HEAD
             # - task: PublishBuildArtifacts@1
             #   displayName: Upload TestResults
             #   condition: always()
@@ -101,13 +102,32 @@ extends:
                 ArtifactType: Container
                 Parallel: true
               - output: buildArtifacts
+=======
+            - task: PublishBuildArtifacts@1
+              displayName: Upload TestResults
+              condition: always()
+              continueOnError: true
+              inputs:
+                pathtoPublish: artifacts/TestResults/$(_BuildConfig)/
+                artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
+                artifactType: Container
+                parallel: true
+            - task: PublishBuildArtifacts@1
+              displayName: Upload package artifacts
+              condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+              inputs:
+>>>>>>> 7ca9507 (Fix indenting)
                 pathtoPublish: artifacts/packages/
                 artifactName: artifacts
                 artifactType: Container
                 parallel: true
 
 
+<<<<<<< HEAD
     - template: eng\common\templates-official\post-build\post-build.yml@self
+=======
+    - template: eng\common\templates-official\post-build\post-build.yml
+>>>>>>> 7ca9507 (Fix indenting)
       parameters:
         # Symbol validation isn't being very reliable lately. This should be enabled back
         # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,10 +11,9 @@ variables:
     value: true
   - name: _BuildConfig
     value: Release
-
-    # used for post-build phases, internal builds only
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - group: DotNet-AspNet-SDLValidation-Params
+  - template: /eng/common/templates-official/variables/pool-providers.yml
+  # used for post-build phases
+  - group: DotNet-AspNet-SDLValidation-Params
 
 # CI and PR triggers
 trigger:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,16 +104,7 @@ extends:
                 PathtoPublish: artifacts/packages/
                 ArtifactName: artifacts
 
-
-<<<<<<< HEAD
-<<<<<<< HEAD
     - template: eng\common\templates-official\post-build\post-build.yml@self
-=======
-    - template: eng\common\templates-official\post-build\post-build.yml
->>>>>>> 7ca9507 (Fix indenting)
-=======
-    - template: eng\common\templates-official\post-build\post-build.yml@self
->>>>>>> 49f745f (Add @self decorators)
       parameters:
         # Symbol validation isn't being very reliable lately. This should be enabled back
         # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,7 +126,6 @@ extends:
         # It's a private repo in github so this won't pass until we create an internal mirror
         enableSourceLinkValidation: false
         publishingInfraVersion: 3
-        publishAssetsImmediately: true
         # This is to enable SDL runs part of Post-Build Validation Stage
         SDLValidationParameters:
           enable: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ stages:
       enableMicrobuild: true
       enablePublishBuildArtifacts: true
       enablePublishTestResults: true
-      enablePublishBuildAssets: true
+      enablePublishBuildAssets: false
       enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
       enableTelemetry: true
       mergeTestResults: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ extends:
     - stage: build
       displayName: Build
       jobs:
-      - template: /eng/common/templates-official/jobs/jobs.yml
+      - template: /eng/common/templates-official/jobs/jobs.yml@self
         parameters:
           enableMicrobuild: true
           enablePublishBuildArtifacts: true
@@ -96,7 +96,7 @@ extends:
                 parallel: true
 
 
-    - template: eng\common\templates-official\post-build\post-build.yml
+    - template: eng\common\templates-official\post-build\post-build.yml@self
       parameters:
         # Symbol validation isn't being very reliable lately. This should be enabled back
         # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,8 @@
 variables:
   - name: _TeamName
     value: AspNetCore
+  - name: TeamName
+    value: AspNetCore
   - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
     value: true
   - name: _PublishUsingPipelines

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,83 +41,83 @@ extends:
     customBuildTags:
     - ES365AIMigrationTooling
 
-stages:
-- stage: build
-  displayName: Build
-  jobs:
-  - template: /eng/common/templates-official/jobs/jobs.yml
-    parameters:
-      enableMicrobuild: true
-      enablePublishBuildArtifacts: true
-      enablePublishTestResults: true
-      enablePublishBuildAssets: false
-      enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
-      enableTelemetry: true
-      mergeTestResults: true
+    stages:
+    - stage: build
+      displayName: Build
       jobs:
-      - job: Windows
-        pool:
-          name: $(DncEngInternalBuildPool)
-          image: 1es-windows-2022-pt
-          os: windows
-        variables:
-          
-        # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-        - group: Publish-Build-Assets
-        - name: _OfficialBuildArgs
-          value: /p:DotNetSignType=$(_SignType)
-                /p:TeamName=$(_TeamName)
-                /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
-                /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-        - name: _SignType
-          value: real
-                
-        steps:
-        - checkout: self
-          clean: true
-        - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_OfficialBuildArgs)
-          displayName: Build and Publish
-        - task: PublishBuildArtifacts@1
-          displayName: Upload TestResults
-          condition: always()
-          continueOnError: true
-          inputs:
-            pathtoPublish: artifacts/TestResults/$(_BuildConfig)/
-            artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
-            artifactType: Container
-            parallel: true
-        - task: PublishBuildArtifacts@1
-          displayName: Upload package artifacts
-          condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
-          inputs:
-            pathtoPublish: artifacts/packages/
-            artifactName: artifacts
-            artifactType: Container
-            parallel: true
+      - template: /eng/common/templates-official/jobs/jobs.yml
+        parameters:
+          enableMicrobuild: true
+          enablePublishBuildArtifacts: true
+          enablePublishTestResults: true
+          enablePublishBuildAssets: false
+          enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
+          enableTelemetry: true
+          mergeTestResults: true
+          jobs:
+          - job: Windows
+            pool:
+              name: $(DncEngInternalBuildPool)
+              image: 1es-windows-2022-pt
+              os: windows
+            variables:
+              
+            # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
+            - group: Publish-Build-Assets
+            - name: _OfficialBuildArgs
+              value: /p:DotNetSignType=$(_SignType)
+                    /p:TeamName=$(_TeamName)
+                    /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+                    /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+            - name: _SignType
+              value: real
+                    
+            steps:
+            - checkout: self
+              clean: true
+            - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_OfficialBuildArgs)
+              displayName: Build and Publish
+            - task: PublishBuildArtifacts@1
+              displayName: Upload TestResults
+              condition: always()
+              continueOnError: true
+              inputs:
+                pathtoPublish: artifacts/TestResults/$(_BuildConfig)/
+                artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
+                artifactType: Container
+                parallel: true
+            - task: PublishBuildArtifacts@1
+              displayName: Upload package artifacts
+              condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+              inputs:
+                pathtoPublish: artifacts/packages/
+                artifactName: artifacts
+                artifactType: Container
+                parallel: true
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: eng\common\templates-official\post-build\post-build.yml
-    parameters:
-      # Symbol validation isn't being very reliable lately. This should be enabled back
-      # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
-      enableSymbolValidation: false
-      enableSigningValidation: true
-      # It's a private repo in github so this won't pass until we create an internal mirror
-      enableSourceLinkValidation: false
-      publishingInfraVersion: 3
-      publishAssetsImmediately: true
-      # This is to enable SDL runs part of Post-Build Validation Stage
-      SDLValidationParameters:
-        enable: true
-        continueOnError: false
-        params: ' -SourceToolsList @("policheck","credscan")
-        -TsaInstanceURL $(_TsaInstanceURL)
-        -TsaProjectName $(_TsaProjectName)
-        -TsaNotificationEmail $(_TsaNotificationEmail)
-        -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-        -TsaBugAreaPath $(_TsaBugAreaPath)
-        -TsaIterationPath $(_TsaIterationPath)
-        -TsaRepositoryName "Crank"
-        -TsaCodebaseName "Crank"
-        -TsaPublish $True
-        -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/eng/PoliCheckExclusions.xml")'
+
+    - template: eng\common\templates-official\post-build\post-build.yml
+      parameters:
+        # Symbol validation isn't being very reliable lately. This should be enabled back
+        # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
+        enableSymbolValidation: false
+        enableSigningValidation: true
+        # It's a private repo in github so this won't pass until we create an internal mirror
+        enableSourceLinkValidation: false
+        publishingInfraVersion: 3
+        publishAssetsImmediately: true
+        # This is to enable SDL runs part of Post-Build Validation Stage
+        SDLValidationParameters:
+          enable: true
+          continueOnError: false
+          params: ' -SourceToolsList @("policheck","credscan")
+          -TsaInstanceURL $(_TsaInstanceURL)
+          -TsaProjectName $(_TsaProjectName)
+          -TsaNotificationEmail $(_TsaNotificationEmail)
+          -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
+          -TsaBugAreaPath $(_TsaBugAreaPath)
+          -TsaIterationPath $(_TsaIterationPath)
+          -TsaRepositoryName "Crank"
+          -TsaCodebaseName "Crank"
+          -TsaPublish $True
+          -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/eng/PoliCheckExclusions.xml")'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,13 +100,9 @@ extends:
               - output: buildArtifacts
                 PathtoPublish: artifacts/TestResults/$(_BuildConfig)/
                 ArtifactName: $(Agent.Os)_$(Agent.JobName) TestResults
-                ArtifactType: Container
-                Parallel: true
               - output: buildArtifacts
-                pathtoPublish: artifacts/packages/
-                artifactName: artifacts
-                artifactType: Container
-                parallel: true
+                PathtoPublish: artifacts/packages/
+                ArtifactName: artifacts
 
 
 <<<<<<< HEAD

--- a/azure-pr-pipelines.yml
+++ b/azure-pr-pipelines.yml
@@ -1,0 +1,128 @@
+#
+# See https://docs.microsoft.com/azure/devops/pipelines/yaml-schema for details
+#
+
+variables:
+  - name: _TeamName
+    value: AspNetCore
+  - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
+    value: true
+  - name: _PublishUsingPipelines
+    value: true
+  - name: _BuildConfig
+    value: Release
+
+# CI and PR triggers
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - '*'
+
+stages:
+- stage: build
+  displayName: Build
+  jobs:
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enableMicrobuild: true
+      enablePublishBuildArtifacts: true
+      enablePublishTestResults: true
+      enablePublishBuildAssets: true
+      enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
+      enableTelemetry: true
+      mergeTestResults: true
+      jobs:
+      # - ${{ if and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - job: Windows
+        pool:
+          name: NetCore-Public
+          demands: ImageOverride -equals windows.vs2022.amd64.open
+        variables:
+        - name: _OfficialBuildArgs
+          value: ''
+        - name: _SignType
+          value: test
+                
+        steps:
+        - checkout: self
+          clean: true
+        - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_OfficialBuildArgs)
+          displayName: Build and Publish
+        - task: PublishBuildArtifacts@1
+          displayName: Upload TestResults
+          condition: always()
+          continueOnError: true
+          inputs:
+            pathtoPublish: artifacts/TestResults/$(_BuildConfig)/
+            artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
+            artifactType: Container
+            parallel: true
+        - task: PublishBuildArtifacts@1
+          displayName: Upload package artifacts
+          condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+          inputs:
+            pathtoPublish: artifacts/packages/
+            artifactName: artifacts
+            artifactType: Container
+            parallel: true
+
+      - job: Ubuntu
+        displayName: 'Ubuntu 20.04'
+        pool:
+          vmImage: ubuntu-latest
+        variables:
+        - name: _SignType
+          value: none
+        - name: _OfficialBuildArgs
+          value: ''
+
+        steps:
+        - checkout: self
+          clean: true
+        - script: eng/common/cibuild.sh
+            --configuration $(_BuildConfig)
+            --prepareMachine
+          displayName: Build
+        - task: PublishBuildArtifacts@1
+          displayName: Upload TestResults
+          condition: always()
+          continueOnError: true
+          inputs:
+            pathtoPublish: artifacts/TestResults/$(_BuildConfig)/
+            artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
+            artifactType: Container
+            parallel: true
+
+      # Tests on macOS are unreliable
+      # - job: macOS
+      #   displayName: 'macOS 10.15'
+      #   pool:
+      #     vmImage: macOS-1015
+      #   variables:
+      #   - name: _SignType
+      #     value: none
+
+      #   - ${{ if and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      #     - name: _OfficialBuildArgs
+      #       value: -p:OfficialBuildId=$(Build.BuildNumber)
+      #   # else
+      #   - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+      #     - name: _OfficialBuildArgs
+      #       value: ''
+      #   steps:
+      #   - checkout: self
+      #     clean: true
+      #   - script: eng/common/cibuild.sh
+      #       --configuration $(_BuildConfig)
+      #       --prepareMachine
+      #     displayName: Build
+      #   - task: PublishBuildArtifacts@1
+      #     displayName: Upload TestResults
+      #     condition: always()
+      #     continueOnError: true
+      #     inputs:
+      #       pathtoPublish: artifacts/TestResults/$(_BuildConfig)/
+      #       artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
+      #       artifactType: Container
+      #       parallel: true


### PR DESCRIPTION
This splits out the current yml AzDO definition into an internal and pr file.

The internal runs have also been configured to use the new internal templates and use the other 1ES approved steps and jobs.

The new public yml has not been tested yet, as I can't create a new pipeline from a yml file just in a branch.