### PR TITLE
Copy Files to Docker

### DIFF
--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -2164,13 +2164,11 @@ namespace Microsoft.Crank.Agent
 
             var containerName = Regex.Replace(imageName, @"[^\w]", "_")+ $"-{job.Id}";
 
-            // TODO: Clean previous images 
-
             // Stop container in case it failed to stop earlier
-            // await ProcessUtil.RunAsync("docker", $"stop {containerName}", throwOnError: false);
+            await ProcessUtil.RunAsync("docker", $"stop {containerName}", throwOnError: false);
 
             // Delete container if the same name already exists
-            // await ProcessUtil.RunAsync("docker", $"rm {imageName}", throwOnError: false);
+            await ProcessUtil.RunAsync("docker", $"rm {imageName}", throwOnError: false);
 
             if (!String.IsNullOrWhiteSpace(job.CpuSet))
             {

--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -2192,7 +2192,6 @@ namespace Microsoft.Crank.Agent
 
             var createCommandResult = await ProcessUtil.RunAsync("docker", $"{createCommand} ",
                 throwOnError: true,
-                onStart: _ => stopwatch.Start(),
                 captureOutput: true,
                 log: true,
                 outputDataReceived: job.BuildLog.AddLine

--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -2215,21 +2215,17 @@ namespace Microsoft.Crank.Agent
                 var filename = attachment.Filename.Replace("\\", "/");
                 var tempFilePath = attachment.TempFilename;
 
-                //    Log.Info($"Creating output file: {filename}");
+                Log.Info($"Copying output file to container: {filename}");
 
-                //    docker container cp --name {containerName} 
-                string copyCommand = "cp ";
-                string dockerCopyCommand = $"cp ./some_file CONTAINER:/work";
-                var copyResult = await ProcessUtil.RunAsync("docker", $"{copyCommand} ",
+                string dockerCopyCommand = $"cp {tempFilePath} {containerName}:{filename}";
+                var copyResult = await ProcessUtil.RunAsync("docker", $"{dockerCopyCommand} ",
                     throwOnError: true,
                     onStart: _ => stopwatch.Start(),
                     captureOutput: true,
                     log: true,
                     outputDataReceived: job.BuildLog.AddLine);
 
-            //    File.Copy(attachment.TempFilename, filename);
-
-            //    File.Delete(attachment.TempFilename);
+                File.Delete(attachment.TempFilename);
             }
 
             // docker start --name {containerName} 

--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -2209,7 +2209,6 @@ namespace Microsoft.Crank.Agent
                 string dockerCopyCommand = $"cp {tempFilePath} {containerName}:{filename}";
                 var copyResult = await ProcessUtil.RunAsync("docker", $"{dockerCopyCommand} ",
                     throwOnError: true,
-                    onStart: _ => stopwatch.Start(),
                     captureOutput: true,
                     log: true,
                     outputDataReceived: job.BuildLog.AddLine);

--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -2187,18 +2187,10 @@ namespace Microsoft.Crank.Agent
                 environmentArguments += $"--memory=\"{job.MemoryLimitInBytes}b\" ";
             }
 
-            // crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/containers.benchmarks.yml --scenario json_aspnet_current --profile local --profile noload
-
-            // --outputFiles source[;destination]
-            // is destination (./app)  or ./ ?
-            // check that destination is set in attachment.Filename
-
             // docker create --name {containerName}
             var createCommand = $"create {environmentArguments} {job.Arguments} --label benchmarks --name {containerName} --privileged --network host {imageName} {job.DockerCommand}";
 
             job.BuildLog.AddLine("docker " + createCommand);
-
-            // TODO: Find out what to do if there is a collision on the name.
 
             var createCommandResult = await ProcessUtil.RunAsync("docker", $"{createCommand} ",
                 throwOnError: true,
@@ -2208,8 +2200,7 @@ namespace Microsoft.Crank.Agent
                 outputDataReceived: job.BuildLog.AddLine
             );
 
-            // Copy attachments
-            // Copy all output attachments
+            // Copy attachments to container.
             foreach (var attachment in job.Attachments)
             {
                 var filename = attachment.Filename.Replace("\\", "/");
@@ -2227,8 +2218,6 @@ namespace Microsoft.Crank.Agent
 
                 File.Delete(attachment.TempFilename);
             }
-
-            // docker start --name {containerName} 
 
             if (job.Collect && job.CollectStartup)
             {


### PR DESCRIPTION
This PR implements the functionality of copying files to a docker container. Changes required to the current implementation include to create, copy the attached files and then start rather than simply running the container.

One caveat here was that the destination path should be the folder name where the files must go rather than the path to the files themselves (CC: @sebastienros). For example:

``crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/containers.benchmarks.yml --scenario json_aspnet_current --profile local --profile noload --application.options.outputFiles "./docs/development.md;app/development.md"`` 

doesn't work as it leads to the filename as: app\development.md\development.md
![image](https://github.com/dotnet/crank/assets/68247673/ac0f5a7b-9e19-4766-9fb5-c84cfd3a5b77)

Also, quotations around the source;[destination] are necessary unlike the typical case of simply uploading a file.

NOTE: The following uploads the file to the / folder:

``crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/containers.benchmarks.yml --scenario json_aspnet_current --profile local --profile noload --application.options.outputFiles ./docs/development.md``.

## Testing

Run from the crank folder:
``crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/containers.benchmarks.yml --scenario json_aspnet_current --profile local --profile noload  --application.options.outputFiles "./docs/*;app/"``

Copied all the md files in doc folder to the container:
![image](https://github.com/dotnet/crank/assets/68247673/b15014e4-934d-48e7-9fb9-5514050648ef)