### PR TITLE
Remove -pt from pool image names as they have been removed.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)
-        image: 1es-windows-2022-pt
+        image: 1es-windows-2022
         os: windows
     customBuildTags:
     - ES365AIMigrationTooling
@@ -59,7 +59,7 @@ extends:
           - job: Windows
             pool:
               name: $(DncEngInternalBuildPool)
-              image: 1es-windows-2022-pt
+              image: 1es-windows-2022
               os: windows
             variables:
               


### PR DESCRIPTION
Remove -pt from pool image names as the images have been removed. Transition started here: https://github.com/dotnet/dnceng/issues/2081 and finished ~2 weeks ago. 