### PR TITLE
fix bombardier miss -b and delete local file

### DIFF
--- a/src/Microsoft.Crank.Jobs.Bombardier/Program.cs
+++ b/src/Microsoft.Crank.Jobs.Bombardier/Program.cs
@@ -135,25 +135,24 @@ namespace Microsoft.Crank.Jobs.Bombardier
             }
 
             // Filename of temporary file containing the body
-            string tempBodyFile = null;
+            string tempBodyFile = null;            
             
-            if (!String.IsNullOrEmpty(bodyFile))
+            if (!string.IsNullOrEmpty(body))
+            {
+                bodyFile = tempBodyFile = Path.GetTempFileName();
+                File.WriteAllText(tempBodyFile, body);
+            }
+            
+            if (!string.IsNullOrEmpty(bodyFile))
             {
                 // Download the body file locally if it's a url, and delete it later
                 if (bodyFile.StartsWith("http", StringComparison.OrdinalIgnoreCase))
                 {
-                    tempBodyFile = await DownloadToTempFile(bodyFile);
-                    bodyFile = tempBodyFile;
+                    bodyFile = tempBodyFile = await DownloadToTempFile(bodyFile);
                 }
 
                 argsList.Add("-f");
                 argsList.Add(bodyFile);
-            }
-            
-            if (!string.IsNullOrEmpty(body))
-            {
-                tempBodyFile = Path.GetTempFileName();
-                File.WriteAllText(tempBodyFile, body);
             }
 
             if (!String.IsNullOrEmpty(certFile) && !String.IsNullOrEmpty(keyFile))


### PR DESCRIPTION
fix #747 

**test for `-b`** 

```yml
  load:
      job: bombardier
      variables:
        serverPort: 5000
        path: /
        verb: POST
        body: '{\"name\":\"World\"}'
```
![image](https://github.com/dotnet/crank/assets/8394988/cc8aef7f-cb65-468f-b274-50a4b01035c3)


**test for delete local file**

Should I write a test for this scenario?