### PR TITLE
Fix JsonSerializationException

### DIFF
--- a/src/Microsoft.Crank.Controller/ResultComparer.cs
+++ b/src/Microsoft.Crank.Controller/ResultComparer.cs
@@ -211,10 +211,10 @@ namespace Microsoft.Crank.Controller
                         summary.Add(new BenchmarkSummary()
                         {
                             Name = benchmark.FullName,
-                            MeanNanoseconds = benchmark.Statistics.Mean,
-                            StandardErrorNanoseconds = benchmark.Statistics.StandardError,
-                            StandardDeviationNanoseconds = benchmark.Statistics.StandardDeviation,
-                            MedianNanoseconds = benchmark.Statistics.Median,
+                            MeanNanoseconds = benchmark.Statistics.Mean ?? double.NaN,
+                            StandardErrorNanoseconds = benchmark.Statistics.StandardError ?? double.NaN,
+                            StandardDeviationNanoseconds = benchmark.Statistics.StandardDeviation ?? double.NaN,
+                            MedianNanoseconds = benchmark.Statistics.Median ?? double.NaN,
                             Gen0 = benchmark.Memory?.Gen0Collections ?? 0,
                             Gen1 = benchmark.Memory?.Gen1Collections ?? 0,
                             Gen2 = benchmark.Memory?.Gen2Collections ?? 0,

--- a/src/Microsoft.Crank.Models/JobResults.cs
+++ b/src/Microsoft.Crank.Models/JobResults.cs
@@ -41,20 +41,20 @@ namespace Microsoft.Crank.Models
 
     public class BenchmarkStatistics
     {
-        public double Min { get; set; }
-        public double Mean { get; set; }
-        public double Median { get; set; }
-        public double Max { get; set; }
-        public double StandardError { get; set; }
-        public double StandardDeviation { get; set; }
+        public double? Min { get; set; }
+        public double? Mean { get; set; }
+        public double? Median { get; set; }
+        public double? Max { get; set; }
+        public double? StandardError { get; set; }
+        public double? StandardDeviation { get; set; }
     }
 
     public class BenchmarkMemory
     {
-        public int Gen0Collections { get; set; }
-        public int Gen1Collections { get; set; }
-        public int Gen2Collections { get; set; }
-        public long BytesAllocatedPerOperation { get; set; }
-        public long TotalOperations { get; set; }
+        public int? Gen0Collections { get; set; }
+        public int? Gen1Collections { get; set; }
+        public int? Gen2Collections { get; set; }
+        public long? BytesAllocatedPerOperation { get; set; }
+        public long? TotalOperations { get; set; }
     }
 }


### PR DESCRIPTION
Fix `JsonSerializationException` if a BenchmarkDotNet benchmark does not generate any results due to an error.

Excerpt from the really long error log where I found this:

```console
 Method    | Job          | Arguments                   | Toolchain              | input    | Mean         | Error        | StdDev     | Gen0     | Gen1     | Gen2     | Allocated  |
---------- |------------- |---------------------------- |----------------------- |--------- |-------------:|-------------:|-----------:|---------:|---------:|---------:|-----------:|
 Solve2015 | AdventOfCode | /p:UseArtifactsOutput=false | Default                | Y2015-01 |     11.89 μs |     3.004 μs |   0.165 μs |   0.0153 |        - |        - |    1.38 KB |
 Solve2015 | ShortRun     | Default                     | InProcessEmitToolchain | Y2015-01 |     14.21 μs |     5.355 μs |   0.294 μs |   0.0153 |        - |        - |    1.38 KB |
 Solve2015 | AdventOfCode | /p:UseArtifactsOutput=false | Default                | Y2015-02 |     65.79 μs |    17.465 μs |   0.957 μs |   0.1221 |        - |        - |   13.36 KB |
 Solve2015 | ShortRun     | Default                     | InProcessEmitToolchain | Y2015-02 |     66.74 μs |     6.283 μs |   0.344 μs |   0.1221 |        - |        - |   13.36 KB |
 Solve2015 | AdventOfCode | /p:UseArtifactsOutput=false | Default                | Y2015-03 |    638.54 μs |   176.788 μs |   9.690 μs |   3.9063 |   0.9766 |        - |  366.81 KB |
 Solve2015 | ShortRun     | Default                     | InProcessEmitToolchain | Y2015-03 |    645.93 μs |    78.475 μs |   4.301 μs |   3.9063 |   0.9766 |        - |  366.81 KB |
 Solve2015 | AdventOfCode | /p:UseArtifactsOutput=false | Default                | Y2015-05 |    739.30 μs |   107.744 μs |   5.906 μs |  13.6719 |        - |        - | 1182.72 KB |
 Solve2015 | ShortRun     | Default                     | InProcessEmitToolchain | Y2015-05 |    754.96 μs |   174.643 μs |   9.573 μs |  13.6719 |        - |        - | 1182.72 KB |
 Solve2015 | AdventOfCode | /p:UseArtifactsOutput=false | Default                | Y2015-07 |           NA |           NA |         NA |       NA |       NA |       NA |         NA |
 Solve2015 | ShortRun     | Default                     | InProcessEmitToolchain | Y2015-07 |           NA |           NA |         NA |       NA |       NA |       NA |         NA |
 Solve2015 | AdventOfCode | /p:UseArtifactsOutput=false | Default                | Y2015-08 |     94.70 μs |     9.176 μs |   0.503 μs |   1.9531 |        - |        - |  163.28 KB |
 Solve2015 | ShortRun     | Default                     | InProcessEmitToolchain | Y2015-08 |     94.84 μs |     3.980 μs |   0.218 μs |   1.9531 |        - |        - |  163.28 KB |
 Solve2015 | AdventOfCode | /p:UseArtifactsOutput=false | Default                | Y2015-11 | 11,218.53 μs | 1,458.577 μs |  79.950 μs |        - |        - |        - |  226.85 KB |
 Solve2015 | ShortRun     | Default                     | InProcessEmitToolchain | Y2015-11 |  9,349.99 μs | 2,417.460 μs | 132.509 μs |        - |        - |        - |  226.87 KB |
 Solve2015 | AdventOfCode | /p:UseArtifactsOutput=false | Default                | Y2015-12 |    705.09 μs |    95.601 μs |   5.240 μs |        - |        - |        - |   68.46 KB |
 Solve2015 | ShortRun     | Default                     | InProcessEmitToolchain | Y2015-12 |    692.83 μs |    68.730 μs |   3.767 μs |        - |        - |        - |   68.45 KB |
 Solve2015 | AdventOfCode | /p:UseArtifactsOutput=false | Default                | Y2015-14 |  1,376.20 μs |   366.381 μs |  20.083 μs |  21.4844 |        - |        - | 1910.47 KB |
 Solve2015 | ShortRun     | Default                     | InProcessEmitToolchain | Y2015-14 |  1,340.80 μs |   326.210 μs |  17.881 μs |  21.4844 |        - |        - | 1910.47 KB |
 Solve2015 | AdventOfCode | /p:UseArtifactsOutput=false | Default                | Y2015-16 |    614.13 μs |    40.272 μs |   2.207 μs |   9.7656 |        - |        - |  830.23 KB |
 Solve2015 | ShortRun     | Default                     | InProcessEmitToolchain | Y2015-16 |    658.76 μs |    63.324 μs |   3.471 μs |   9.7656 |        - |        - |  830.23 KB |
 Solve2015 | AdventOfCode | /p:UseArtifactsOutput=false | Default                | Y2015-17 | 27,518.06 μs |   938.458 μs |  51.440 μs | 500.0000 | 500.0000 | 500.0000 | 8397.01 KB |
 Solve2015 | ShortRun     | Default                     | InProcessEmitToolchain | Y2015-17 | 27,421.18 μs | 1,052.893 μs |  57.713 μs | 500.0000 | 500.0000 | 500.0000 | 8398.51 KB |
 Solve2015 | AdventOfCode | /p:UseArtifactsOutput=false | Default                | Y2015-21 |    963.68 μs |    27.376 μs |   1.501 μs |  21.4844 |        - |        - | 1768.03 KB |
 Solve2015 | ShortRun     | Default                     | InProcessEmitToolchain | Y2015-21 |    973.09 μs |   145.341 μs |   7.967 μs |  21.4844 |        - |        - | 1768.02 KB |
 Solve2015 | AdventOfCode | /p:UseArtifactsOutput=false | Default                | Y2015-23 |     84.44 μs |     8.099 μs |   0.444 μs |   1.5869 |        - |        - |  133.38 KB |
 Solve2015 | ShortRun     | Default                     | InProcessEmitToolchain | Y2015-23 |     88.85 μs |     5.136 μs |   0.282 μs |   1.5869 |        - |        - |  133.38 KB |

Benchmarks with issues:
  PuzzleBenchmarks.Solve2015: AdventOfCode(Arguments=/p:UseArtifactsOutput=false, IterationCount=3, LaunchCount=1, WarmupCount=3) [input=Y2015-07]
  PuzzleBenchmarks.Solve2015: ShortRun(Toolchain=InProcessEmitToolchain, IterationCount=3, LaunchCount=1, WarmupCount=3) [input=Y2015-07]


Results saved in '/tmp/microbenchmarks-2015.pr.json'
crank compare /tmp/microbenchmarks-2015.base.json /tmp/microbenchmarks-2015.pr.json

Newtonsoft.Json.JsonSerializationException: Error converting value {null} to type 'System.Int64'. Path 'Benchmarks[8].Memory.BytesAllocatedPerOperation', line 514, position 42.
 ---> System.InvalidCastException: Null object cannot be converted to a value type.
   at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.EnsureType(JsonReader reader, Object value, CultureInfo culture, JsonContract contract, Type targetType)
   --- End of inner exception stack trace ---
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.EnsureType(JsonReader reader, Object value, CultureInfo culture, JsonContract contract, Type targetType)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateList(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty containerProperty, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, Object existingValue, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonConvert.DeserializeObject(String value, Type type, JsonSerializerSettings settings)
   at Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value, JsonSerializerSettings settings)
   at Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value)
   at Microsoft.Crank.Controller.ResultComparer.<>c.<Compare>b__0_0(String filename) in /_/src/Microsoft.Crank.Controller/ResultComparer.cs:line 33
   at System.Linq.Utilities.<>c__DisplayClass2_0`3.<CombineSelectors>b__0(TSource x)
   at System.Linq.Enumerable.SelectListIterator`2.Fill(ReadOnlySpan`1 source, Span`1 destination, Func`2 func)
   at System.Linq.Enumerable.SelectListIterator`2.ToList()
   at Microsoft.Crank.Controller.ResultComparer.Compare(IEnumerable`1 filenames, JobResults jobResults, Benchmark[] benchmarks, String jobName) in /_/src/Microsoft.Crank.Controller/ResultComparer.cs:line 32
   at Microsoft.Crank.Controller.Program.<>c__DisplayClass60_1.<Main>b__3() in /_/src/Microsoft.Crank.Controller/Program.cs:line 250
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.<>c__DisplayClass144_0.<OnExecute>b__0(CancellationToken _)
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.ExecuteAsync(String[] args, CancellationToken cancellationToken)
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.Execute(String[] args)
   at Microsoft.Crank.Controller.Program.Main(String[] args) in /_/src/Microsoft.Crank.Controller/Program.cs:line 751
   at Microsoft.Crank.PullRequestBot.Program.RunCrank(RunOptions options, String[] args) in /_/src/Microsoft.Crank.PullRequestBot/Program.cs:line 929
An error occurred during crank run
```