### PR TITLE
Remove redundant condition for NET 9

### DIFF
--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -4341,13 +4341,6 @@ namespace Microsoft.Crank.Agent
         /// </summary>
         private static async Task<(string Runtime, string Desktop, string AspNet, string Sdk)> GetCurrentVersions(string targetFramework)
         {
-            // There are currently no release for net9.0
-            // Remove once there is at least a preview and a "release-metadata" file
-            if (targetFramework.Equals("net9.0", StringComparison.OrdinalIgnoreCase))
-            {
-                return (null, null, null, null);
-            }
-
             var frameworkVersion = targetFramework.Substring(targetFramework.Length - 3); // 6.0
             var metadataUrl = $"https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/{frameworkVersion}/releases.json";
 


### PR DESCRIPTION
Remove now-redundant condition for .NET 9.

I was trying to run crank for a .NET 9 application and got this error:

```
[10:38:35 INF] Patching project file '/tmp/benchmarks-agent/benchmarks-server-2278/quz1y0ad.4mq/src/API/API.csproj'
[10:38:35 INF] Runtime:  (Current)
[10:38:35 INF] SDK:  (Current)
[10:38:35 INF] ASP.NET:  (Current)
[10:38:35 INF] Patching existing global.json file
[10:38:35 INF] An unexpected error occurred while building the job. System.AggregateException: One or more errors occurred. (Object reference not set to an instance of an object.)
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.Crank.Agent.Startup.CloneRestoreAndBuild(String path, Job job, String dotnetHome, CancellationToken cancellationToken) in /_/src/Microsoft.Crank.Agent/Startup.cs:line 2855
   at Microsoft.Crank.Agent.Startup.<>c__DisplayClass85_3.<<ProcessJobs>b__22>d.MoveNext() in /_/src/Microsoft.Crank.Agent/Startup.cs:line 972
   --- End of inner exception stack trace ---
```

Tracing through the code, I found this leftover code from when `net9.0` support was added prior to .NET 9 preview 1 shipping as part of #634.
