### PR TITLE
Fix NullReferenceException

### DIFF
--- a/src/Microsoft.Crank.Controller/ResultComparer.cs
+++ b/src/Microsoft.Crank.Controller/ResultComparer.cs
@@ -211,10 +211,10 @@ namespace Microsoft.Crank.Controller
                         summary.Add(new BenchmarkSummary()
                         {
                             Name = benchmark.FullName,
-                            MeanNanoseconds = benchmark.Statistics.Mean ?? double.NaN,
-                            StandardErrorNanoseconds = benchmark.Statistics.StandardError ?? double.NaN,
-                            StandardDeviationNanoseconds = benchmark.Statistics.StandardDeviation ?? double.NaN,
-                            MedianNanoseconds = benchmark.Statistics.Median ?? double.NaN,
+                            MeanNanoseconds = benchmark.Statistics?.Mean ?? double.NaN,
+                            StandardErrorNanoseconds = benchmark.Statistics?.StandardError ?? double.NaN,
+                            StandardDeviationNanoseconds = benchmark.Statistics?.StandardDeviation ?? double.NaN,
+                            MedianNanoseconds = benchmark.Statistics?.Median ?? double.NaN,
                             Gen0 = benchmark.Memory?.Gen0Collections ?? 0,
                             Gen1 = benchmark.Memory?.Gen1Collections ?? 0,
                             Gen2 = benchmark.Memory?.Gen2Collections ?? 0,


### PR DESCRIPTION
Fix `NullReferenceException` if a benchmark produces no results.

The problem was previously masked before the change I made in #753.

```console
BenchmarkDotNet v0.14.0, Ubuntu 22.04.4 LTS (Jammy Jellyfish)
AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
.NET SDK 9.0.100-rc.1.24452.12
  [Host] : .NET 9.0.0 (9.0.24.43107), X64 RyuJIT AVX2

Job=ShortRun  Toolchain=InProcessEmitToolchain  IterationCount=3  
LaunchCount=1  WarmupCount=3  

 Method    | input    | Mean         | Error        | StdDev    | Gen0     | Gen1     | Gen2     | Allocated  |
---------- |--------- |-------------:|-------------:|----------:|---------:|---------:|---------:|-----------:|
 Solve2015 | Y2015-01 |     11.71 μs |     2.001 μs |  0.110 μs |   0.0153 |        - |        - |    1.38 KB |
 Solve2015 | Y2015-02 |     62.14 μs |     4.976 μs |  0.273 μs |   0.1221 |        - |        - |   13.36 KB |
 Solve2015 | Y2015-03 |    624.91 μs |   122.811 μs |  6.732 μs |   3.9063 |   0.9766 |        - |  366.83 KB |
 Solve2015 | Y2015-05 |    692.36 μs |    56.585 μs |  3.102 μs |  12.6953 |        - |        - |  1088.9 KB |
 Solve2015 | Y2015-07 |           NA |           NA |        NA |       NA |       NA |       NA |         NA |
 Solve2015 | Y2015-08 |     88.11 μs |     1.143 μs |  0.063 μs |   1.9531 |        - |        - |  163.28 KB |
 Solve2015 | Y2015-11 |  8,688.29 μs | 1,532.263 μs | 83.989 μs |        - |        - |        - |  226.94 KB |
 Solve2015 | Y2015-12 |    685.57 μs |    47.053 μs |  2.579 μs |        - |        - |        - |   68.44 KB |
 Solve2015 | Y2015-14 |  1,177.25 μs |   437.217 μs | 23.965 μs |  21.4844 |        - |        - | 1910.48 KB |
 Solve2015 | Y2015-16 |    607.58 μs |   118.503 μs |  6.496 μs |   9.7656 |        - |        - |  830.24 KB |
 Solve2015 | Y2015-17 | 26,798.03 μs |    72.332 μs |  3.965 μs | 500.0000 | 500.0000 | 500.0000 | 8374.31 KB |
 Solve2015 | Y2015-21 |    876.18 μs |     8.521 μs |  0.467 μs |  19.5313 |        - |        - | 1651.79 KB |
 Solve2015 | Y2015-23 |     89.12 μs |     7.569 μs |  0.415 μs |   1.5869 |        - |        - |  133.34 KB |

Benchmarks with issues:
  PuzzleBenchmarks.Solve2015: ShortRun(Toolchain=InProcessEmitToolchain, IterationCount=3, LaunchCount=1, WarmupCount=3) [input=Y2015-07]


Results saved in '/tmp/microbenchmarks-2015.pr.json'
crank compare /tmp/microbenchmarks-2015.base.json /tmp/microbenchmarks-2015.pr.json

System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.Crank.Controller.ResultComparer.DisplayDiff(IEnumerable`1 allBenchmarks, IEnumerable`1 allNames) in /_/src/Microsoft.Crank.Controller/ResultComparer.cs:line 211
   at Microsoft.Crank.Controller.ResultComparer.Compare(IEnumerable`1 filenames, JobResults jobResults, Benchmark[] benchmarks, String jobName) in /_/src/Microsoft.Crank.Controller/ResultComparer.cs:line 64
   at Microsoft.Crank.Controller.Program.<>c__DisplayClass60_1.<Main>b__3() in /_/src/Microsoft.Crank.Controller/Program.cs:line 250
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.<>c__DisplayClass144_0.<OnExecute>b__0(CancellationToken _)
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.ExecuteAsync(String[] args, CancellationToken cancellationToken)
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.Execute(String[] args)
   at Microsoft.Crank.Controller.Program.Main(String[] args) in /_/src/Microsoft.Crank.Controller/Program.cs:line 751
   at Microsoft.Crank.PullRequestBot.Program.RunCrank(RunOptions options, String[] args) in /_/src/Microsoft.Crank.PullRequestBot/Program.cs:line 929
```