### PR TITLE
Fix run script comment's location

### DIFF
--- a/docker/agent/run.sh
+++ b/docker/agent/run.sh
@@ -24,11 +24,11 @@ do
     esac
 done
 
+# cgroupfs is mapped to allow docker to create cgroups without permissions issues (cgroup v2)
+# docker.sock is mapped to be able to manage other docker instances from this one
 docker run -it --name $name -d --network host --restart always \
     --log-opt max-size=1G --privileged \
-    # cgroupfs is mapped to allow docker to create cgroups without permissions issues (cgroup v2)
     -v /sys/fs/cgroup/:/sys/fs/cgroup/ \
-    # docker.sock is mapped to be able to manage other docker instances from this one
     -v /var/run/docker.sock:/var/run/docker.sock \
     crank-agent \
     --url $url $others


### PR DESCRIPTION
Current syntax doesn't work, and the valid one is ugly and creates a subshell for each comment:

```
--someoption `# some comment` \
```