### PR TITLE
Update MessagePack to 2.5.187

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="Jint" Version="3.0.0" />
     <PackageVersion Include="JsonSchema.Net" Version="3.3.2" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
-    <PackageVersion Include="MessagePack" Version="2.2.85" />
+    <PackageVersion Include="MessagePack" Version="2.5.187" />
     <PackageVersion Include="Microsoft.AspNetCore.Hosting.WindowsServices" Version="5.0.12" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
     <PackageVersion Include="Microsoft.Azure.Relay" Version="3.0.1" />


### PR DESCRIPTION
This update is required to resolve a component governance alert