### PR TITLE
fix: specify proper cmd arg for `beforeScript`, `afterScript` commands

### DIFF
--- a/src/Microsoft.Crank.Controller/Documentation.cs
+++ b/src/Microsoft.Crank.Controller/Documentation.cs
@@ -102,9 +102,9 @@ internal class Documentation
   --[JOB].options.outputFiles <filename>                        Output files that will be copied in the published folder after the application is built. Accepts globing patterns and recursive marker (**). Format is 'path[;destination]'. Path can be a URL. e.g., c:\build\Microsoft.AspNetCore.Mvc.dll, c:\files\samples\picture.png;wwwroot\picture.png. If provided, the destination needs to be a folder name, relative to the published path.
   --[JOB].options.reuseSource <true|false>                      Reuse local or remote sources across benchmarks for the same source.
   --[JOB].options.reuseBuild <true|false>                       Reuse build files across benchmarks. Don't use with floating runtime versions.
-  --[JOB].options.beforeScript <commandline>                    A command line to execute before the job is started. Current directory is the same as the project or docker file.
-  --[JOB].options.afterScript <commandline>                     A command line to execute after the job is stopped. Current directory is the same as the project or docker file.
-  --[JOB].options.stoppingScript <commandline>                  A command line to execute after the job is stopped. Current directory is the same as the project or docker file.
+  --[JOB].beforeScript <commandline>                            A command line to execute before the job is started. Current directory is the same as the project or docker file.
+  --[JOB].afterScript <commandline>                             A command line to execute after the job is stopped. Current directory is the same as the project or docker file.
+  --[JOB].stoppingScript <commandline>                          A command line to execute after the job is stopped. Current directory is the same as the project or docker file.
   --[JOB].options.noGitIgnore <true|false>                      Whether to ignore the .gitignore file when upload local source or build files. Default is false, meaning the local gitignore file is respected.
 
   For script based arguments the following environment variables are available: 

--- a/src/Microsoft.Crank.Controller/README.md
+++ b/src/Microsoft.Crank.Controller/README.md
@@ -156,9 +156,9 @@ Run 'crank [command] -?|-h|--help' for more information about a command.
   --[JOB].options.outputFiles <filename>                        Output files that will be copied in the published folder after the application is built. Accepts globing patterns and recursive marker (**). Format is 'path[;destination]'. Path can be a URL. e.g., c:\build\Microsoft.AspNetCore.Mvc.dll, c:\files\samples\picture.png;wwwroot\picture.png. If provided, the destination needs to be a folder name, relative to the published path.
   --[JOB].options.reuseSource <true|false>                      Reuse local or remote sources across benchmarks for the same source.
   --[JOB].options.reuseBuild <true|false>                       Reuse build files across benchmarks. Don't use with floating runtime versions.
-  --[JOB].options.beforeScript <commandline>                    A command line to execute before the job is started. Current directory is the same as the project or docker file.
-  --[JOB].options.afterScript <commandline>                     A command line to execute after the job is stopped. Current directory is the same as the project or docker file.
-  --[JOB].options.stoppingScript <commandline>                  A command line to execute after the job is stopped. Current directory is the same as the project or docker file.
+  --[JOB].beforeScript <commandline>                            A command line to execute before the job is started. Current directory is the same as the project or docker file.
+  --[JOB].afterScript <commandline>                             A command line to execute after the job is stopped. Current directory is the same as the project or docker file.
+  --[JOB].stoppingScript <commandline>                          A command line to execute after the job is stopped. Current directory is the same as the project or docker file.
   --[JOB].options.noGitIgnore <true|false>                      Whether to ignore the .gitignore file when upload local source or build files. Default is false, meaning the local gitignore file is respected.
 
   For script based arguments the following environment variables are available:


### PR DESCRIPTION
I tried to include the `beforeScript` in one of automatically set benchmarks, and it did not work with argument `--application.options.beforeScript "..."` because part of configuration path was not found:
>
crank --config https://raw.githubusercontent.com/DeagleGross/Benchmarks/refs/heads/dmkorolev/tls-httpsys-fixes/scenarios/tls.benchmarks.yml --scenario mTls-handshakes-httpsys --profile aspnet-perf-win --application.framework net10.0 --application.options.beforeScript "cmd.exe /c dir"
`Could not find part of the configuration path: '[application.options.beforeScript, cmd.exe /c dir]'`

However, `--application.beforeScript` worked:
> crank --config https://raw.githubusercontent.com/DeagleGross/Benchmarks/refs/heads/dmkorolev/tls-httpsys-fixes/scenarios/tls.benchmarks.yml --scenario mTls-handshakes-httpsys --profile aspnet-perf-win --application.framework net10.0 --application.beforeScript "cmd.exe /c dir"
A new version is available on NuGet.org (0.2.0-alpha.25056.1). Run 'dotnet tool update Microsoft.Crank.Controller -g --version "0.2.0-*"' to update
[01:59:12.553] Running session '1f8fe58dd57c45358a7be7ec483401b0' with description ''
[01:59:13.753] Failed to authenticate with Azure CLI: Please run 'az login' to set up account
[01:59:14.241] Starting job 'application' ...

crank agent source code is asserting my attempt (usage is `job.xxxScript` instead of `job.Options.xxxScript`) https://github.com/dotnet/crank/blob/a10455925de353afc509012ec97113981b88d239/src/Microsoft.Crank.Agent/Startup.cs#L2230
https://github.com/dotnet/crank/blob/a10455925de353afc509012ec97113981b88d239/src/Microsoft.Crank.Agent/Startup.cs#L1826
https://github.com/dotnet/crank/blob/a10455925de353afc509012ec97113981b88d239/src/Microsoft.Crank.Agent/Startup.cs#L1614