### PR TITLE
feat: support SslProtocol parameter for httpClient job

### DIFF
--- a/src/Microsoft.Crank.Jobs.HttpClient/Program.cs
+++ b/src/Microsoft.Crank.Jobs.HttpClient/Program.cs
@@ -596,7 +596,7 @@ namespace Microsoft.Crank.Jobs.HttpClientClient
             var maxLatency = 0D;
             var totalLatency = 0D;
             var transferred = 0L;
-            var measuringStart = 0L;
+            var measuringStart = -1L;
 
             var sw = new Stopwatch();
             sw.Start();
@@ -652,7 +652,7 @@ namespace Microsoft.Crank.Jobs.HttpClientClient
                     {
                         if (measuringStart == 0)
                         {
-                            measuringStart = sw.ElapsedTicks;
+                            measuringStart = sw.ElapsedTicks - 1;
                         }
 
                         transferred += responseMessage.Content.Headers.ContentLength ?? 0;
@@ -709,16 +709,7 @@ namespace Microsoft.Crank.Jobs.HttpClientClient
                 }
             }
 
-            long throughput = 0;
-            try
-            {
-                throughput = transferred / ((sw.ElapsedTicks - measuringStart) / Stopwatch.Frequency);
-            }
-            catch (DivideByZeroException ex)
-            {
-                Log("Error during throughput calculation: {0}", ex.Message);
-            }
-
+            var throughput = transferred / ((sw.ElapsedTicks - measuringStart) / Stopwatch.Frequency);
 
             if (!String.IsNullOrWhiteSpace(Script) && !worker.Script.GetValue("stop").IsUndefined())
             {

--- a/src/Microsoft.Crank.Jobs.HttpClient/Program.cs
+++ b/src/Microsoft.Crank.Jobs.HttpClient/Program.cs
@@ -184,27 +184,28 @@ namespace Microsoft.Crank.Jobs.HttpClientClient
 
                 Headers = new List<string>(optionHeaders.Values);
 
-                var sslProtocols = ParseSslProtocols(optionSslProtocols.Values);
-                _httpClientHandler.SslProtocols = sslProtocols;
-                Log("Using sslProtocols: {0}. input: {1}", sslProtocols, string.Join(";", optionSslProtocols.Values));
-
-                static SslProtocols ParseSslProtocols(List<string> inputProtocols)
+                if (optionSslProtocols.HasValue())
                 {
-                    if (inputProtocols is null)
+                    var sslProtocols = ParseSslProtocols(optionSslProtocols.Values);
+                    if (sslProtocols is not SslProtocols.None)
                     {
-                        return SslProtocols.Tls12 | SslProtocols.Tls13;
+                        Log("Using sslProtocols: {0}", sslProtocols);
+                        _httpClientHandler.SslProtocols = sslProtocols;
                     }
 
-                    var result = SslProtocols.None;
-                    foreach (var protocol in inputProtocols)
+                    static SslProtocols ParseSslProtocols(List<string> inputProtocols)
                     {
-                        if (Enum.TryParse<SslProtocols>(protocol, ignoreCase: true, out var mask))
+                        var result = SslProtocols.None;
+                        foreach (var protocol in inputProtocols)
                         {
-                            result |= mask;
+                            if (Enum.TryParse<SslProtocols>(protocol, ignoreCase: true, out var mask))
+                            {
+                                result |= mask;
+                            }
                         }
-                    }
 
-                    return result;
+                        return result;
+                    }
                 }
 
                 if (optionBody.HasValue())

--- a/src/Microsoft.Crank.Jobs.HttpClient/Program.cs
+++ b/src/Microsoft.Crank.Jobs.HttpClient/Program.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Crank.Jobs.HttpClientClient
         public static int WarmupTimeSeconds { get; set; }
         public static int ExecutionTimeSeconds { get; set; }
         public static int Connections { get; set; }
+        public static SslProtocols? TlsVersions { get; set; }
         public static List<string> Headers { get; set; }
         public static byte[] Body { get; set; }
         public static Version Version { get; set; }
@@ -189,8 +190,7 @@ namespace Microsoft.Crank.Jobs.HttpClientClient
                     var sslProtocols = ParseSslProtocols(optionSslProtocols.Values);
                     if (sslProtocols is not SslProtocols.None)
                     {
-                        Log("Using sslProtocols: {0}", sslProtocols);
-                        _httpClientHandler.SslProtocols = sslProtocols;
+                        TlsVersions = sslProtocols;
                     }
 
                     static SslProtocols ParseSslProtocols(List<string> inputProtocols)
@@ -475,6 +475,12 @@ namespace Microsoft.Crank.Jobs.HttpClientClient
                             UseProxy = false,
                             AutomaticDecompression = DecompressionMethods.None
                         };
+
+                        if (TlsVersions is not null)
+                        {
+                            Log("Using sslProtocols: {0}", TlsVersions);
+                            _httpHandler.SslOptions.EnabledSslProtocols = TlsVersions;
+                        }
 
                         // Accept any SSL certificate
                         _httpHandler.SslOptions.RemoteCertificateValidationCallback += (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) => true;

--- a/src/Microsoft.Crank.Jobs.HttpClient/Program.cs
+++ b/src/Microsoft.Crank.Jobs.HttpClient/Program.cs
@@ -184,7 +184,10 @@ namespace Microsoft.Crank.Jobs.HttpClientClient
 
                 Headers = new List<string>(optionHeaders.Values);
 
-                _httpClientHandler.SslProtocols = ParseSslProtocols(optionSslProtocols.Values);
+                var sslProtocols = ParseSslProtocols(optionSslProtocols.Values);
+                _httpClientHandler.SslProtocols = sslProtocols;
+                Log("Using sslProtocols: {0}", sslProtocols);
+
                 static SslProtocols ParseSslProtocols(List<string> inputProtocols)
                 {
                     if (inputProtocols is null)

--- a/src/Microsoft.Crank.Jobs.HttpClient/Program.cs
+++ b/src/Microsoft.Crank.Jobs.HttpClient/Program.cs
@@ -709,7 +709,8 @@ namespace Microsoft.Crank.Jobs.HttpClientClient
                 }
             }
 
-            var throughput = transferred / ((sw.ElapsedTicks - measuringStart) / Stopwatch.Frequency);
+            var throughput = transferred / ((double)(sw.ElapsedTicks - measuringStart) / Stopwatch.Frequency);
+            var throughputBps = (long)throughput;
 
             if (!String.IsNullOrWhiteSpace(Script) && !worker.Script.GetValue("stop").IsUndefined())
             {
@@ -733,7 +734,7 @@ namespace Microsoft.Crank.Jobs.HttpClientClient
                 SocketErrors = socketErrors,
                 LatencyMaxMs = maxLatency / Stopwatch.Frequency * 1000,
                 LatencyMeanMs = (totalLatency / counters.Sum()) / Stopwatch.Frequency * 1000,
-                ThroughputBps = throughput
+                ThroughputBps = throughputBps
             };
         }
     }

--- a/src/Microsoft.Crank.Jobs.HttpClient/Program.cs
+++ b/src/Microsoft.Crank.Jobs.HttpClient/Program.cs
@@ -479,7 +479,7 @@ namespace Microsoft.Crank.Jobs.HttpClientClient
                         if (TlsVersions is not null)
                         {
                             Log("Using sslProtocols: {0}", TlsVersions);
-                            _httpHandler.SslOptions.EnabledSslProtocols = TlsVersions;
+                            _httpHandler.SslOptions.EnabledSslProtocols = TlsVersions.Value;
                         }
 
                         // Accept any SSL certificate

--- a/src/Microsoft.Crank.Jobs.HttpClient/Program.cs
+++ b/src/Microsoft.Crank.Jobs.HttpClient/Program.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Crank.Jobs.HttpClientClient
 
                 var sslProtocols = ParseSslProtocols(optionSslProtocols.Values);
                 _httpClientHandler.SslProtocols = sslProtocols;
-                Log("Using sslProtocols: {0}", sslProtocols);
+                Log("Using sslProtocols: {0}. input: {1}", sslProtocols, string.Join(";", optionSslProtocols.Values));
 
                 static SslProtocols ParseSslProtocols(List<string> inputProtocols)
                 {

--- a/src/Microsoft.Crank.Jobs.HttpClient/Program.cs
+++ b/src/Microsoft.Crank.Jobs.HttpClient/Program.cs
@@ -604,6 +604,7 @@ namespace Microsoft.Crank.Jobs.HttpClientClient
             var totalLatency = 0D;
             var transferred = 0L;
             var measuringStart = 0L;
+
             var sw = new Stopwatch();
             sw.Start();
 
@@ -715,7 +716,16 @@ namespace Microsoft.Crank.Jobs.HttpClientClient
                 }
             }
 
-            var throughput = transferred / ((sw.ElapsedTicks - measuringStart) / Stopwatch.Frequency);
+            long throughput = 0;
+            try
+            {
+                throughput = transferred / ((sw.ElapsedTicks - measuringStart) / Stopwatch.Frequency);
+            }
+            catch (DivideByZeroException ex)
+            {
+                Log("Error during throughput calculation: {0}", ex.Message);
+            }
+
 
             if (!String.IsNullOrWhiteSpace(Script) && !worker.Script.GetValue("stop").IsUndefined())
             {

--- a/src/Microsoft.Crank.Jobs.HttpClient/httpclient.yml
+++ b/src/Microsoft.Crank.Jobs.HttpClient/httpclient.yml
@@ -28,5 +28,5 @@ jobs:
       httpVersion: 1.1
       certPath: # the path or url of the certificate used for authentication
       certPwd: # the password of the certificate specified in certPath
-      sslProtocols: # the SSL protocols to use, e.g. Tls12, Tls13.
-    arguments: '--url "{{serverScheme}}://{{serverAddress}}:{{serverPort}}{{path}}" --connections {{connections}} --warmup {{warmup}} --duration {{duration}} {{headers[presetHeaders]}} --version {{httpVersion}} {% if certPath %} --cert {{certPath}} {% endif %} {% if certPwd %} --certpwd {{certPwd}} {% endif %} {% if sslProtocols %} --sslProtocols {{sslProtocols}} {% endif %}'
+      sslProtocol: # the SSL protocol to use, e.g. Tls12, Tls13.
+    arguments: '--url "{{serverScheme}}://{{serverAddress}}:{{serverPort}}{{path}}" --connections {{connections}} --warmup {{warmup}} --duration {{duration}} {{headers[presetHeaders]}} --version {{httpVersion}} {% if certPath %} --cert {{certPath}} {% endif %} {% if certPwd %} --certpwd {{certPwd}} {% endif %} {% if sslProtocol %} --ssl-protocol {{sslProtocol}} {% endif %}'

--- a/src/Microsoft.Crank.Jobs.HttpClient/httpclient.yml
+++ b/src/Microsoft.Crank.Jobs.HttpClient/httpclient.yml
@@ -29,4 +29,4 @@ jobs:
       certPath: # the path or url of the certificate used for authentication
       certPwd: # the password of the certificate specified in certPath
       sslProtocols: # the SSL protocols to use, e.g. Tls12, Tls13.
-    arguments: '--url "{{serverScheme}}://{{serverAddress}}:{{serverPort}}{{path}}" --connections {{connections}} --warmup {{warmup}} --duration {{duration}} {{headers[presetHeaders]}} --version {{httpVersion}} {% if certPath %} --cert {{certPath}} {% endif %} {% if certPwd %} --certpwd {{certPwd}} {% endif %}'
+    arguments: '--url "{{serverScheme}}://{{serverAddress}}:{{serverPort}}{{path}}" --connections {{connections}} --warmup {{warmup}} --duration {{duration}} {{headers[presetHeaders]}} --version {{httpVersion}} {% if certPath %} --cert {{certPath}} {% endif %} {% if certPwd %} --certpwd {{certPwd}} {% endif %} --sslProtocols {{sslProtocols}}'

--- a/src/Microsoft.Crank.Jobs.HttpClient/httpclient.yml
+++ b/src/Microsoft.Crank.Jobs.HttpClient/httpclient.yml
@@ -10,8 +10,8 @@
 jobs:
   httpclient:
     source:
-      repository: https://github.com/deaglegross/crank.git
-      branchOrCommit: "dmkorolev/httpclient/add-tls-protocol-override"
+      repository: https://github.com/dotnet/crank.git
+      branchOrCommit: main
       project: src/Microsoft.Crank.Jobs.HttpClient/Microsoft.Crank.Jobs.HttpClient.csproj
     readyStateText: Http Client
     isConsoleApp: true

--- a/src/Microsoft.Crank.Jobs.HttpClient/httpclient.yml
+++ b/src/Microsoft.Crank.Jobs.HttpClient/httpclient.yml
@@ -28,4 +28,5 @@ jobs:
       httpVersion: 1.1
       certPath: # the path or url of the certificate used for authentication
       certPwd: # the password of the certificate specified in certPath
+      sslProtocols: # the SSL protocols to use, e.g. Tls12, Tls13.
     arguments: '--url "{{serverScheme}}://{{serverAddress}}:{{serverPort}}{{path}}" --connections {{connections}} --warmup {{warmup}} --duration {{duration}} {{headers[presetHeaders]}} --version {{httpVersion}} {% if certPath %} --cert {{certPath}} {% endif %} {% if certPwd %} --certpwd {{certPwd}} {% endif %}'

--- a/src/Microsoft.Crank.Jobs.HttpClient/httpclient.yml
+++ b/src/Microsoft.Crank.Jobs.HttpClient/httpclient.yml
@@ -29,4 +29,4 @@ jobs:
       certPath: # the path or url of the certificate used for authentication
       certPwd: # the password of the certificate specified in certPath
       sslProtocols: # the SSL protocols to use, e.g. Tls12, Tls13.
-    arguments: '--url "{{serverScheme}}://{{serverAddress}}:{{serverPort}}{{path}}" --connections {{connections}} --warmup {{warmup}} --duration {{duration}} {{headers[presetHeaders]}} --version {{httpVersion}} {% if certPath %} --cert {{certPath}} {% endif %} {% if certPwd %} --certpwd {{certPwd}} {% endif %} --sslProtocols {{sslProtocols}}'
+    arguments: '--url "{{serverScheme}}://{{serverAddress}}:{{serverPort}}{{path}}" --connections {{connections}} --warmup {{warmup}} --duration {{duration}} {{headers[presetHeaders]}} --version {{httpVersion}} {% if certPath %} --cert {{certPath}} {% endif %} {% if certPwd %} --certpwd {{certPwd}} {% endif %} {% if sslProtocols %} --sslProtocols {{sslProtocols}} {% endif %}'

--- a/src/Microsoft.Crank.Jobs.HttpClient/httpclient.yml
+++ b/src/Microsoft.Crank.Jobs.HttpClient/httpclient.yml
@@ -10,8 +10,8 @@
 jobs:
   httpclient:
     source:
-      repository: https://github.com/dotnet/crank.git
-      branchOrCommit: main
+      repository: https://github.com/deaglegross/crank.git
+      branchOrCommit: "dmkorolev/httpclient/add-tls-protocol-override"
       project: src/Microsoft.Crank.Jobs.HttpClient/Microsoft.Crank.Jobs.HttpClient.csproj
     readyStateText: Http Client
     isConsoleApp: true


### PR DESCRIPTION
Adding an option to explicitly set the sslProtocol version to use on `SocketsHttpHandler`