### PR TITLE
Handle non-304 response when checking urls

### DIFF
--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -5825,7 +5825,8 @@ namespace Microsoft.Crank.Agent
                 using var response = _httpClient.Send(httpMessage);
 
                 // If the file exists, it will return a 304, otherwise a 404
-                if (response.StatusCode == HttpStatusCode.NotModified)
+                // Some servers ignore the IfModifiedSince header, so check for success too
+                if (response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.NotModified)
                 {
                     return true;
                 }


### PR DESCRIPTION
Some servers ignore the If-Modified-Since header and return 200.