### PR TITLE
feat: update crank-agents to install latest openssl

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -54,9 +54,16 @@ RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         g++ make binutils autoconf automake autotools-dev libtool pkg-config \
-        zlib1g-dev libcunit1-dev libssl-dev libxml2-dev libev-dev libevent-dev libjansson-dev \
+        zlib1g-dev libcunit1-dev libxml2-dev libev-dev libevent-dev libjansson-dev \
         libc-ares-dev libjemalloc-dev libsystemd-dev \
         python-is-python3 python3-dev python3-setuptools
+
+ENV DEBIAN_FRONTEND=noninteractive
+# Add Debian testing repository
+RUN echo 'deb http://deb.debian.org/debian testing main' >> /etc/apt/sources.list 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    -t testing openssl=3.4.0-2 libssl-dev=3.4.0-2
 
 # If nghttp2 build fail just ignore it
 ENV NGHTTP2_VERSION=1.58.0


### PR DESCRIPTION
verified by running `./build.sh` on wsl and then ran the container. Unfortunately, it is not available in the main distribution (maybe i did not find it correctly http://ftp.debian.org/debian/).
![image](https://github.com/user-attachments/assets/0ed17bf1-6f30-45f8-9f8e-f29657e40092)

If you want, I can change base image from `mcr.microsoft.com/dotnet/sdk:8.0` to `mcr.microsoft.com/dotnet/sdk:8.0-alpine` like is done in [TLS benchmarks](https://github.com/aspnet/Benchmarks/blob/3773f786bb25e1f344370be398a91bf236cf3f07/src/BenchmarksApps/TLS/Kestrel/Dockerfile#L2) which provides easier way to install latest openssl version.
