### PR TITLE
fix: dont dispose machine-counters eventsource for linux cpu stats collection

### DIFF
--- a/src/Microsoft.Crank.Agent/MachineCounters/MachineCountersEventSource.cs
+++ b/src/Microsoft.Crank.Agent/MachineCounters/MachineCountersEventSource.cs
@@ -5,6 +5,9 @@ namespace Microsoft.Crank.Agent.MachineCounters
     [EventSource(Name = "MachineCountersEventSource")]
     internal class MachineCountersEventSource : EventSource
     {
+        /// <notes>
+        /// Should not be disposed -> is a singleton for the application lifetime
+        /// </notes>
         public static readonly MachineCountersEventSource Log = new MachineCountersEventSource();
 
         public void WriteCounterValue(string counterName, double value) 

--- a/src/Microsoft.Crank.Agent/MachineCounters/OS/LinuxMachineCpuUsageEmitter.cs
+++ b/src/Microsoft.Crank.Agent/MachineCounters/OS/LinuxMachineCpuUsageEmitter.cs
@@ -95,9 +95,9 @@ namespace Microsoft.Crank.Agent.MachineCounters.OS
 
         public void Dispose()
         {
-            _eventSource?.Dispose();
-
-            _vmstatProcess?.Close(); // is that sufficient to stop the process?
+            _vmstatProcess.Kill();
+            _vmstatProcess.WaitForExit();
+            Log.Info($"vmstat process killed and stopped");
             _vmstatProcess?.Dispose();
         }
     }

--- a/src/Microsoft.Crank.Agent/ProcessUtil.cs
+++ b/src/Microsoft.Crank.Agent/ProcessUtil.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Crank.Agent
             process.Start();
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
-            Console.WriteLine($"Started process '{process.Id}' for streaming");
+            Log.Info($"Started process '{process.ProcessName}#{process.Id}' for streaming");
 
             return process;
         }

--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -5159,6 +5159,7 @@ namespace Microsoft.Crank.Agent
 
             // The event pipe session needs to be disposed after the source is interrupted
             machineCountersController?.Dispose();
+            machineCountersController = null;
             context.EventPipeSession?.Dispose();
             context.EventPipeSession = null;
 


### PR DESCRIPTION
On linux cpu collection emitting was working only for the first run due to disposal of singleton `MachineCountersEventSource.Log`.
I removed `_eventSource?.Dispose();` invocation, and adjusted logging a bit. 