### PR TITLE
Clean-up and finish the release yaml

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -1,4 +1,3 @@
-# The pool section has been filled with placeholder values, check the following link for guidance: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-pipeline-templates/onboardingesteams/overview, replace the pool section with your hosted pool, os, and image name. If you are using a Linux image, you must specify an additional windows image for SDL: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-pipeline-templates/features/sdlanalysis/overview#how-to-specify-a-windows-pool-for-the-sdl-source-analysis-stage
 trigger: none
 name: $(Date:yyyyMMdd).$(Rev:r)
 parameters:
@@ -28,8 +27,7 @@ extends:
       image: windows-latest
       os: windows
     stages:
-    - stage: Publish_Stage
-      displayName: Publish Crank NuGet Packages
+    - stage: Publish
       jobs:
       - job: Publish_Job
         displayName: Publish Crank NuGet Packages
@@ -68,5 +66,5 @@ extends:
                   nuget push -Source $env:NuGetFeed -ApiKey $env:NuGetApiKey $_.FullName
                 }
               }
-            env:
-              NuGetApiKey: $(NuGetApiKey)
+          env:
+            NuGetApiKey: $(NuGetApiKey)

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -34,7 +34,6 @@ extends:
       - job: Publish_Job
         displayName: Publish Crank NuGet Packages
         condition: succeeded()
-        type: releaseJob
         timeoutInMinutes: 0
         templateContext:
           inputs:

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -5,8 +5,6 @@ parameters:
   type: boolean
   default: false
 variables:
-- name: NuGetApiKey
-  value: 
 - name: NuGetFeed
   value: https://api.nuget.org/v3/index.json
 resources:
@@ -50,7 +48,7 @@ extends:
               if(!$env:NuGetFeed) {
                 throw "Missing 'NuGetFeed' variable!"
               }
-              if(!$env:NuGetApiKey) {
+              if(!$env:NUGET_API_KEY) {
                 throw "Missing 'NuGetApiKey' variable!"
               }
               Write-Host "Dry run: $env:DryRun"
@@ -61,7 +59,7 @@ extends:
                   Write-Host "Would publish $name"
                 }
               } else {
-                if(!$env:NuGetApiKey) {
+                if(!$env:NUGET_API_KEY) {
                   throw "Missing 'NuGetApiKey' variable!"
                 }
                 Get-ChildItem "$(Pipeline.Workspace)\PackageArtifacts\" -Filter *.nupkg | ForEach-Object {
@@ -71,5 +69,5 @@ extends:
                 }
               }
           env:
-            NuGetApiKey: $(NuGetApiKey)
+            NUGET_API_KEY: $(NuGetApiKey)
             DryRun: ${{ parameters.DryRun }}

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -1,9 +1,5 @@
 trigger: none
 name: $(Date:yyyyMMdd).$(Rev:r)
-parameters:
-- name: DryRun
-  type: boolean
-  default: false
 variables:
 - name: NuGetFeed
   value: https://api.nuget.org/v3/index.json
@@ -40,25 +36,16 @@ extends:
         steps:
         - task: NuGetToolInstaller@1
           displayName: Install NuGet
-        - task: PowerShell@2
-          displayName: Publish NuGet Packages
-          inputs:
-            targetType: inline
-            script: |-
-              if(!$env:NuGetFeed) {
-                throw "Missing 'NuGetFeed' variable!"
-              }
-              if(!$env:NUGET_API_KEY) {
-                throw "Missing 'NuGetApiKey' variable!"
-              }
-              Write-Host "Dry run: $env:DryRun"
-              if($env:DryRun) {
-                Write-Host "Dry run enabled. The following packages would have been published:"
-                Get-ChildItem "$(Pipeline.Workspace)\PackageArtifacts\" -Filter *.nupkg | ForEach-Object {
-                  $name = $_.Name
-                  Write-Host "Would publish $name"
+        
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+          - task: PowerShell@2
+            displayName: Publish NuGet Packages
+            inputs:
+              targetType: inline
+              script: |-
+                if(!$env:NuGetFeed) {
+                  throw "Missing 'NuGetFeed' variable!"
                 }
-              } else {
                 if(!$env:NUGET_API_KEY) {
                   throw "Missing 'NuGetApiKey' variable!"
                 }
@@ -67,7 +54,5 @@ extends:
                   Write-Host "Publishing $name"
                   nuget push -Source $env:NuGetFeed -ApiKey $env:NuGetApiKey $_.FullName
                 }
-              }
-          env:
-            NUGET_API_KEY: $(NuGetApiKey)
-            DryRun: ${{ parameters.DryRun }}
+            env:
+              NUGET_API_KEY: $(NuGetApiKey)

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -23,7 +23,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool:
-      name: NetCore1ESPool-Svc-Internal
+      name: NetCore1ESPool-Internal
       image: 1es-windows-2022
 
     stages:
@@ -50,7 +50,8 @@ extends:
               if(!$env:NuGetFeed) {
                 throw "Missing 'NuGetFeed' variable!"
               }
-              if(${{ parameters.DryRun }}) {
+              Write-Host "Dry run: $env:DryRun"
+              if($env:DryRun) {
                 Write-Host "Dry run enabled. The following packages would have been published:"
                 Get-ChildItem "$(Pipeline.Workspace)\PackageArtifacts\" -Filter *.nupkg | ForEach-Object {
                   $name = $_.Name
@@ -68,3 +69,4 @@ extends:
               }
           env:
             NuGetApiKey: $(NuGetApiKey)
+            DryRun: ${{ parameters.DryRun }}

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -23,9 +23,9 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool:
-      name: Azure Pipelines
-      image: windows-latest
-      os: windows
+      name: NetCore1ESPool-Svc-Internal
+      image: 1es-windows-2022
+
     stages:
     - stage: Publish
       jobs:

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -50,6 +50,9 @@ extends:
               if(!$env:NuGetFeed) {
                 throw "Missing 'NuGetFeed' variable!"
               }
+              if(!$env:NuGetApiKey) {
+                throw "Missing 'NuGetApiKey' variable!"
+              }
               Write-Host "Dry run: $env:DryRun"
               if($env:DryRun) {
                 Write-Host "Dry run enabled. The following packages would have been published:"


### PR DESCRIPTION
Clean-up and finish the release yaml. This consisted of properly setting the pool to use, updating how the NuGetApiKey is passed in, and putting the publish step itself behind having to be run from main.

Test run with the dryrun features still included, but that shows variables are set properly and packages loaded: https://dev.azure.com/dnceng/internal/_build/results?buildId=2641796&view=results

Final test run with the main branch filter: https://dev.azure.com/dnceng/internal/_build/results?buildId=2642486&view=results. It correctly did not do the actual publish.