### PR TITLE
feat: add support for custom processes cpu collection

### DIFF
--- a/src/Microsoft.Crank.Agent/MachineCounters/MachineCountersController.cs
+++ b/src/Microsoft.Crank.Agent/MachineCounters/MachineCountersController.cs
@@ -210,14 +210,14 @@ public class MachineCountersController : IDisposable
     [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "has a check for OS")]
     List<IMachinePerformanceCounterEmitter> GetAndRegisterProcessCpuUsageEmitters()
     {
-        var processNames = _job.ProcessesCpuToCollect;
-        if (processNames is null || processNames.Count == 0)
+
+        if (_job.AdditionalProcesses is null || _job.AdditionalProcesses.Count == 0)
         {
             return null;
         }
 
         var cpuEmitters = new List<IMachinePerformanceCounterEmitter>();
-        foreach (var processName in processNames.Distinct())
+        foreach (var processName in _job.AdditionalProcesses.Distinct())
         {
             var measurementName = Measurements.GetBenchmarkProcessCpu(processName);
 

--- a/src/Microsoft.Crank.Agent/MachineCounters/OS/IMachinePerformanceCounterEmitter.cs
+++ b/src/Microsoft.Crank.Agent/MachineCounters/OS/IMachinePerformanceCounterEmitter.cs
@@ -7,6 +7,6 @@ namespace Microsoft.Crank.Agent.MachineCounters.OS
         string MeasurementName { get; }
         string CounterName { get; }
 
-        void Start();
+        bool TryStart();
     }
 }

--- a/src/Microsoft.Crank.Agent/MachineCounters/OS/LinuxMachineCpuUsageEmitter.cs
+++ b/src/Microsoft.Crank.Agent/MachineCounters/OS/LinuxMachineCpuUsageEmitter.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Crank.Agent.MachineCounters.OS
             CounterName = counterName;
         }
 
-        public void Start()
+        public bool TryStart()
         {
             try
             {
@@ -48,10 +48,13 @@ namespace Microsoft.Crank.Agent.MachineCounters.OS
                     {
                         Log.Warning("vmstat error: " + error);
                     });
+
+                return true;
             }
             catch (Exception ex)
             {
-                Log.Error(ex, $"error during emitting machine-level counter {nameof(LinuxMachineCpuUsageEmitter)}");
+                Log.Error(ex, $"Error starting {nameof(LinuxMachineCpuUsageEmitter)}");
+                return false;
             }
         }
 

--- a/src/Microsoft.Crank.Agent/MachineCounters/OS/WindowsMachineCpuUsageEmitter.cs
+++ b/src/Microsoft.Crank.Agent/MachineCounters/OS/WindowsMachineCpuUsageEmitter.cs
@@ -37,9 +37,10 @@ namespace Microsoft.Crank.Agent.MachineCounters.OS
             MeasurementName = measurementName;
         }
 
-        public void Start()
+        public bool TryStart()
         {
             _timer = new Timer(_ => WritePerformanceData(), null, TimeSpan.Zero, _interval);
+            return true;
         }
 
         public void Dispose()

--- a/src/Microsoft.Crank.Agent/Measurements.cs
+++ b/src/Microsoft.Crank.Agent/Measurements.cs
@@ -20,6 +20,7 @@
         public const string BenchmarksNetCoreAppVersion = "NetCoreAppVersion";
 
         public const string BenchmarksCpuGlobal = "benchmarks/cpu/global";
-        public const string BenchmarksLsassCpu = "benchmarks/lsass/cpu";
+        public const string BenchmarksProcessCpuFormat = "benchmarks/{0}/cpu";
+        public static string GetBenchmarkProcessCpu(string processName) => string.Format(BenchmarksProcessCpuFormat, processName);
     }
 }

--- a/src/Microsoft.Crank.Controller/Documentation.cs
+++ b/src/Microsoft.Crank.Controller/Documentation.cs
@@ -55,6 +55,7 @@ internal class Documentation
   --[JOB].dotnetTraceProviders <profile|provider|clrevent>      A comma-separated list of trace providers. By default the profile 'cpu-sampling' is used. See 
                                                                 https://github.com/dotnet/diagnostics/blob/master/documentation/dotnet-trace-instructions.md for details. 
                                                                 e.g., ""Microsoft-DotNETCore-SampleProfiler, gc-verbose, JIT+Contention"".
+  --[JOB].additionalProcesses <process-name>                    Name of the processes for which the CPU usage should be recorded. Can be used multiple times to define multiple values.
   --[JOB].options.traceOutput <filename>                        The name of the trace file. Can be a file prefix (app will add *.DATE*.zip) , or a specific name and no DATE* 
                                                                 will be added e.g., c:\traces\mytrace
   --[JOB].options.collectCounters <true|false>                  Whether to collect dotnet counters. If set and 'counterProviders' is not, System.Runtime will be used by default.

--- a/src/Microsoft.Crank.Controller/README.md
+++ b/src/Microsoft.Crank.Controller/README.md
@@ -107,9 +107,9 @@ Run 'crank [command] -?|-h|--help' for more information about a command.
   --[JOB].profileType <true|false>                              The name of the profiler to use. Values: "ultra", "dotnet-trace" (default), "perfview"
   --[JOB].dotnetTrace <true|false>                              Whether to collect a diagnostics trace using dotnet-trace.
   --[JOB].dotnetTraceProviders <profile|provider|clrevent>      A comma-separated list of trace providers. By default the profile 'cpu-sampling' is used. See
-  --[JOB].processesCpuToCollect <process-name>                  Names of processes which CPU usage should be collected. Can be used multiple times to define multiple values.
                                                                 https://github.com/dotnet/diagnostics/blob/master/documentation/dotnet-trace-instructions.md for details.
                                                                 e.g., "Microsoft-DotNETCore-SampleProfiler, gc-verbose, JIT+Contention".
+  --[JOB].additionalProcesses <process-name>                    Name of the processes for which the CPU usage should be recorded. Can be used multiple times to define multiple values.
   --[JOB].options.traceOutput <filename>                        The name of the trace file. Can be a file prefix (app will add *.DATE*.zip) , or a specific name and no DATE*
                                                                 will be added e.g., c:\traces\mytrace
   --[JOB].options.collectCounters <true|false>                  Whether to collect dotnet counters. If set and 'counterProviders' is not, System.Runtime will be used by default.

--- a/src/Microsoft.Crank.Controller/README.md
+++ b/src/Microsoft.Crank.Controller/README.md
@@ -107,6 +107,7 @@ Run 'crank [command] -?|-h|--help' for more information about a command.
   --[JOB].profileType <true|false>                              The name of the profiler to use. Values: "ultra", "dotnet-trace" (default), "perfview"
   --[JOB].dotnetTrace <true|false>                              Whether to collect a diagnostics trace using dotnet-trace.
   --[JOB].dotnetTraceProviders <profile|provider|clrevent>      A comma-separated list of trace providers. By default the profile 'cpu-sampling' is used. See
+  --[JOB].processesCpuToCollect <process-name>                  Names of processes which CPU usage should be collected. Can be used multiple times to define multiple values.
                                                                 https://github.com/dotnet/diagnostics/blob/master/documentation/dotnet-trace-instructions.md for details.
                                                                 e.g., "Microsoft-DotNETCore-SampleProfiler, gc-verbose, JIT+Contention".
   --[JOB].options.traceOutput <filename>                        The name of the trace file. Can be a file prefix (app will add *.DATE*.zip) , or a specific name and no DATE*

--- a/src/Microsoft.Crank.Models/Job.cs
+++ b/src/Microsoft.Crank.Models/Job.cs
@@ -309,6 +309,11 @@ namespace Microsoft.Crank.Models
         public bool CollectDependencies { get; set; }
 
         /// <summary>
+        /// if specified, will try to collect CPU usage for the processes
+        /// </summary>
+        public List<string> ProcessesCpuToCollect { get; set; } = [];
+
+        /// <summary>
         /// Whether to patch the TFM of project references.
         /// </summary>
         public bool PatchReferences { get; set; } = false;
@@ -449,11 +454,6 @@ namespace Microsoft.Crank.Models
         public List<string> OutputArchives { get; } = [];
         public bool BenchmarkDotNet { get; set; }
         public bool? CollectCounters { get; set; }
-        /// <summary>
-        /// In contrast to <see cref="CollectCounters"/>, collects the machine-level counters (not process-level).
-        /// note: undocumented before upcoming changes
-        /// </summary>
-        public bool? CollectLsass { get; set; }
         public List<string> CounterProviders { get; } = [];
 
         // Don't clone and don't build if already cloned and built. 

--- a/src/Microsoft.Crank.Models/Job.cs
+++ b/src/Microsoft.Crank.Models/Job.cs
@@ -309,9 +309,9 @@ namespace Microsoft.Crank.Models
         public bool CollectDependencies { get; set; }
 
         /// <summary>
-        /// if specified, will try to collect CPU usage for the processes
+        /// Names of additional processes to track.
         /// </summary>
-        public List<string> ProcessesCpuToCollect { get; set; } = [];
+        public List<string> AdditionalProcesses { get; set; } = [];
 
         /// <summary>
         /// Whether to patch the TFM of project references.


### PR DESCRIPTION
Added option `--job.processesCpuToCollect` (multi-option) to collect cpu stats for the specific processes. Supported OS is Windows only (so far).

example:
> --config "D:\code\crank\samples\local\local.benchmarks.yml" --scenario hello --profile local --application.processesCpuToCollect "**lsass**" --application.processesCpuToCollect "**taskmgr**"

gives the output with additional 2 stats:
![image](https://github.com/user-attachments/assets/3d17392a-9c17-4423-a1ab-6f28b32d2f81)
