### PR TITLE
Use floating version for openssl

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -63,7 +63,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN echo 'deb http://deb.debian.org/debian testing main' >> /etc/apt/sources.list 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    -t testing openssl=3.4.0-2 libssl-dev=3.4.0-2
+    -t testing openssl=3.4.* libssl-dev=3.4.*
 
 # If nghttp2 build fail just ignore it
 ENV NGHTTP2_VERSION=1.58.0


### PR DESCRIPTION
Current 3.4.0-2 version is failing