### PR TITLE
fix: revert non-admin scripting usage

### DIFF
--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -4565,7 +4565,7 @@ namespace Microsoft.Crank.Agent
             if (!String.IsNullOrEmpty(job.BeforeScript))
             {
                 var segments = job.BeforeScript.Split(' ', 2);
-                var result = await ProcessUtil.RunAsync(segments[0], segments.Length > 1 ? segments[1] : "", workingDirectory: workingDirectory, log: true, outputDataReceived: text => job.Output.AddLine(text), runAsRoot: true);
+                var result = await ProcessUtil.RunAsync(segments[0], segments.Length > 1 ? segments[1] : "", workingDirectory: workingDirectory, log: true, outputDataReceived: text => job.Output.AddLine(text), runAsRoot: false);
             }
 
             var commandLine = benchmarksDll ?? "";

--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -2232,7 +2232,7 @@ namespace Microsoft.Crank.Agent
                 };
 
                 var segments = job.BeforeScript.Split(' ', 2);
-                var processResult = await ProcessUtil.RunAsync(segments[0], segments.Length > 1 ? segments[1] : "", workingDirectory: workingDirectory, log: true, outputDataReceived: job.Output.AddLine, environmentVariables: environmentVariables, runAsRoot: true);
+                var processResult = await ProcessUtil.RunAsync(segments[0], segments.Length > 1 ? segments[1] : "", workingDirectory: workingDirectory, log: true, outputDataReceived: job.Output.AddLine, environmentVariables: environmentVariables, runAsRoot: false);
             }
 
             if (cancellationToken.IsCancellationRequested)

--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -1829,7 +1829,7 @@ namespace Microsoft.Crank.Agent
                                     };
 
                                     var segments = job.AfterScript.Split(' ', 2);
-                                    var processResult = await ProcessUtil.RunAsync(segments[0], segments.Length > 1 ? segments[1] : "", log: true, workingDirectory: workingDirectory, environmentVariables: environmentVariables, runAsRoot: true);
+                                    var processResult = await ProcessUtil.RunAsync(segments[0], segments.Length > 1 ? segments[1] : "", log: true, workingDirectory: workingDirectory, environmentVariables: environmentVariables, runAsRoot: false);
 
                                     // TODO: Update the output with the result of AfterScript, and change the driver so that it polls the job a last time even when the job is stopped
                                     // if there is an AfterScript


### PR DESCRIPTION
It appears, that non-admin rights is enough to run scripts.
Moreover, we cant run `afterScript` in admin mode, because also passes in the env variables
```
                                    var environmentVariables = new Dictionary<string, string>()
                                    {
                                        ["CRANK_PROCESS_ID"] = job.TrackedProcessId.ToString(),
                                        ["CRANK_WORKING_DIRECTORY"] = workingDirectory
                                    };
```

and one cant use ENV variables when `process.StartInfo.UseShellExecute = true` which is required for admin rights (see `process.StartInfo.Verb = "runas";`).