### PR TITLE
fix: minor error handling improvement in pipelining client

### DIFF
--- a/src/Microsoft.Crank.Jobs.PipeliningClient/HttpConnection.cs
+++ b/src/Microsoft.Crank.Jobs.PipeliningClient/HttpConnection.cs
@@ -92,8 +92,13 @@ namespace Microsoft.Crank.Jobs.PipeliningClient
             _pipe = new Pipe();
         }
 
-        public async Task ConnectAsync()
+        public async Task TryConnectAsync()
         {
+            if (_socket.Connected && _stream is not null)
+            {
+                return;
+            }
+
             await _socket.ConnectAsync(_hostEndPoint);
             var networkStream = new NetworkStream(_socket, ownsSocket: true);
 

--- a/src/Microsoft.Crank.Jobs.PipeliningClient/pipelining.yml
+++ b/src/Microsoft.Crank.Jobs.PipeliningClient/pipelining.yml
@@ -27,4 +27,6 @@ jobs:
       serverPort: 5000
       path: /
       customHeaders: [ ] # list of headers with the format: '<name1>: <value1>', e.g. [ 'content-type: application/json' ]. In yml should look like: - "content-type: application/json"
-    arguments: "--url \"{{serverScheme}}://{{serverAddress}}:{{serverPort}}{{path}}\" --connections {{connections}} --warmup {{warmup}} --duration {{duration}} --pipeline {{pipeline}} {{headers[presetHeaders]}} {% for h in customHeaders %}{% assign s = h | split : ':' %}--header \"{{ s[0] }}: {{ s[1] | strip }}\" {% endfor %}"
+      detailedResponseStats: false
+      verboseConnectionLogs: false
+    arguments: "--url \"{{serverScheme}}://{{serverAddress}}:{{serverPort}}{{path}}\" --connections {{connections}} --warmup {{warmup}} --duration {{duration}} --pipeline {{pipeline}} {{headers[presetHeaders]}} {% for h in customHeaders %}{% assign s = h | split : ':' %}--header \"{{ s[0] }}: {{ s[1] | strip }}\" {% endfor %} {% if detailedResponseStats == true %} --detailedResponseStats {% endif %} {% if verboseConnectionLogs == true %} --verboseConnectionLogs {% endif %}"


### PR DESCRIPTION
fixing error
> [STDERR] Unhandled exception. System.Net.Sockets.SocketException (110): Connection timed out
[STDERR]    at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
[STDERR]    at System.Threading.Tasks.ValueTask.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
[STDERR] --- End of stack trace from previous location ---
[STDERR]    at Microsoft.Crank.Jobs.PipeliningClient.HttpConnection.ConnectAsync() in /tmp/benchmarks-agent/benchmarks-server-1/z2amnisn.51n/src/Microsoft.Crank.Jobs.PipeliningClient/HttpConnection.cs:line 97
[STDERR]    at Microsoft.Crank.Jobs.PipeliningClient.Program.DoWorkAsync() in /tmp/benchmarks-agent/benchmarks-server-1/z2amnisn.51n/src/Microsoft.Crank.Jobs.PipeliningClient/Program.cs:line 213
[STDERR]    at Microsoft.Crank.Jobs.PipeliningClient.Program.RunAsync() in /tmp/benchmarks-agent/benchmarks-server-1/z2amnisn.51n/src/Microsoft.Crank.Jobs.PipeliningClient/Program.cs:line 137

and improving logging because today client spams with "connection started / connection closed"