### PR TITLE
Fix crank-agent run.sh variable existence check and minor casing mismatch fix.

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 as build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 
 COPY . .
 

--- a/docker/agent/run.sh
+++ b/docker/agent/run.sh
@@ -25,17 +25,17 @@ do
     esac
 done
 
-if [ -n "CRANK_AGENT_AZURE_RELAY_CERT_CLIENT_ID" ]
+if [ -n "$CRANK_AGENT_AZURE_RELAY_CERT_CLIENT_ID" ]
 then
     dockerargs+=" --env CRANK_AGENT_AZURE_RELAY_CERT_CLIENT_ID"
 fi
 
-if [ -n "CRANK_AGENT_AZURE_RELAY_CERT_TENANT_ID" ]
+if [ -n "$CRANK_AGENT_AZURE_RELAY_CERT_TENANT_ID" ]
 then
     dockerargs+=" --env CRANK_AGENT_AZURE_RELAY_CERT_TENANT_ID"
 fi
 
-if [ -n "CRANK_AGENT_AZURE_RELAY_CERT_PATH" ]
+if [ -n "$CRANK_AGENT_AZURE_RELAY_CERT_PATH" ]
 then
     dockerargs+=" -v $CRANK_AGENT_AZURE_RELAY_CERT_PATH:/certs/relay.pfx --env CRANK_AGENT_AZURE_RELAY_CERT_PATH=/certs/relay.pfx"
 fi


### PR DESCRIPTION
run.sh was previously checking for the existence of strings (which will always cause the checks to return true) rather than the variable that was meant to be checked. Also fixed a minor casing mismatch that is causing a warning when building the crank-agent dockerfile.

Tested the changes locally and they work as expected. The dockerfile still builds, but without the warning, and the additional docker args are correctly passed when the vars exist.