### PR TITLE
Support job files in Azure Dev Ops Worker

### DIFF
--- a/src/Microsoft.Crank.AzureDevOpsWorker/JobPayload.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/JobPayload.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Text;
 using System.Text.Json;
+using System.Collections.Generic;
 
 namespace Microsoft.Crank.AzureDevOpsWorker
 {
@@ -28,6 +29,9 @@ namespace Microsoft.Crank.AzureDevOpsWorker
 
         // A JavaScript condition that must evaluate to true. "job" 
         public string Condition { get; set; }
+
+        // Map of relative file path to create -> base64-encoded content
+        public Dictionary<string, string> Files { get; set; } = [];
 
         public static JobPayload Deserialize(byte[] data)
         {

--- a/src/Microsoft.Crank.AzureDevOpsWorker/Microsoft.Crank.AzureDevOpsWorker.csproj
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/Microsoft.Crank.AzureDevOpsWorker.csproj
@@ -29,6 +29,11 @@
     <ProjectReference Include="..\Microsoft.Crank.Models\Microsoft.Crank.Models.csproj" />
   </ItemGroup>
   
+  <!-- Expose internals to the test project so it can call helper methods without reflection -->
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.Crank.IntegrationTests" />
+  </ItemGroup>
+  
   <ItemGroup>
     <None Update="jobs.example.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Microsoft.Crank.AzureDevOpsWorker/Program.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/Program.cs
@@ -373,7 +373,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
 
             foreach (var file in jobPayload.Files)
             {
-                var relativePath = file.Key?.Replace('\\', '/');
+                var relativePath = file.Key?.Replace('\\', Path.DirectorySeparatorChar);
                 if (string.IsNullOrWhiteSpace(relativePath))
                 {
                     Console.WriteLine($"{LogNow} Skipping empty file path entry.");
@@ -383,13 +383,12 @@ namespace Microsoft.Crank.AzureDevOpsWorker
                 var targetPath = Path.GetFullPath(Path.Combine(baseDir, relativePath));
 
                 // Ensure targetPath stays within baseDir to prevent path traversal
-                var normalizedBaseDir = Path.GetFullPath(baseDir).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-                var normalizedTarget = Path.GetFullPath(targetPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                var normalizedBaseDir = baseDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                var normalizedTarget = targetPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
                 // Allow baseDir itself (e.g., "./") and any child path
                 var baseWithSep = normalizedBaseDir + Path.DirectorySeparatorChar;
-                if (!(normalizedTarget.Equals(normalizedBaseDir, StringComparison.OrdinalIgnoreCase) ||
-                      normalizedTarget.StartsWith(baseWithSep, StringComparison.OrdinalIgnoreCase)))
+                if (!normalizedTarget.StartsWith(baseWithSep, StringComparison.OrdinalIgnoreCase))
                 {
                     Console.WriteLine($"{LogNow} Skipping unsafe path: {relativePath}");
                     continue;

--- a/src/Microsoft.Crank.AzureDevOpsWorker/Program.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/Program.cs
@@ -403,7 +403,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
                 }
                 catch (FormatException)
                 {
-                    Console.WriteLine($"{LogNow} Invalid base64 content for file: {relativePath}. Skipping.");
+                    Console.WriteLine($"{LogNow} Invalid base64 content for file: {relativePath}. Skipping. Content: {file.Value} \n\n");
                 }
             }
         }

--- a/src/Microsoft.Crank.AzureDevOpsWorker/Program.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/Program.cs
@@ -134,9 +134,6 @@ namespace Microsoft.Crank.AzureDevOpsWorker
 
                 if (Verbose)
                 {
-                    // Truncate verbose payload logging to avoid huge console output
-                    var payloadB64 = Convert.ToBase64String(bodyArray);
-                    var max = 2048;
                     // Log only payload metadata to avoid exposing sensitive content
                     Console.WriteLine($"{LogNow} Payload metadata: byte length = {bodyArray.Length}");
                 }
@@ -419,7 +416,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
         // Create a unique temp working directory
         private static string CreateTempWorkingDirectory()
         {
-            var dir = Path.Combine(Path.GetTempPath(), "crank-" + Guid.NewGuid().ToString("N"));
+            var dir = Path.Combine(Directory.GetCurrentDirectory(), "crank-" + Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(dir);
             return dir;
         }

--- a/src/Microsoft.Crank.AzureDevOpsWorker/Program.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/Program.cs
@@ -410,7 +410,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
                 }
                 catch (FormatException)
                 {
-                    Console.WriteLine($"{LogNow} Invalid base64 content for file: {relativePath}. Skipping. Content: {file.Value} \n\n");
+                    Console.WriteLine($"{LogNow} Invalid base64 content for file: {relativePath}. Skipping.");
                 }
             }
         }

--- a/src/Microsoft.Crank.AzureDevOpsWorker/Program.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/Program.cs
@@ -359,7 +359,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
 
         private static string LogNow => $"[{DateTime.Now.ToString("hh:mm:ss.fff")}]";
 
-        private static void MaterializeFiles(JobPayload jobPayload, string workingDirectory)
+        internal static void MaterializeFiles(JobPayload jobPayload, string workingDirectory)
         {
             if (jobPayload?.Files == null || jobPayload.Files.Count == 0)
             {

--- a/src/Microsoft.Crank.AzureDevOpsWorker/Program.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/Program.cs
@@ -137,7 +137,8 @@ namespace Microsoft.Crank.AzureDevOpsWorker
                     // Truncate verbose payload logging to avoid huge console output
                     var payloadB64 = Convert.ToBase64String(bodyArray);
                     var max = 2048;
-                    Console.WriteLine($"{LogNow} Payload (Base64, len={payloadB64.Length}): {payloadB64.Substring(0, Math.Min(payloadB64.Length, max))}{(payloadB64.Length > max ? "...(truncated)" : "")}");
+                    // Log only payload metadata to avoid exposing sensitive content
+                    Console.WriteLine($"{LogNow} Payload metadata: byte length = {bodyArray.Length}");
                 }
 
                 // The only way to detect if a Task still needs to be executed is to download all the details of all tasks (there is no API to retrieve the status of a single task.

--- a/test/Microsoft.Crank.IntegrationTests/AzureWorkerTests.cs
+++ b/test/Microsoft.Crank.IntegrationTests/AzureWorkerTests.cs
@@ -123,10 +123,7 @@ namespace Microsoft.Crank.IntegrationTests
                     }
                 };
 
-                var method = typeof(Program).GetMethod("MaterializeFiles", BindingFlags.NonPublic | BindingFlags.Static);
-                Assert.NotNull(method);
-
-                method.Invoke(null, new object[] { payload, tmp });
+                Program.MaterializeFiles(payload, tmp);
 
                 var aPath = Path.Combine(tmp, "nested", "dir", "a.txt");
                 var bPath = Path.Combine(tmp, "b.json");
@@ -166,10 +163,7 @@ namespace Microsoft.Crank.IntegrationTests
                     }
                 };
 
-                var method = typeof(Program).GetMethod("MaterializeFiles", BindingFlags.NonPublic | BindingFlags.Static);
-                Assert.NotNull(method);
-
-                method.Invoke(null, new object[] { payload, tmp });
+                Program.MaterializeFiles(payload, tmp);
 
                 // Traversal should be skipped
                 Assert.False(File.Exists(outsidePath));

--- a/test/Microsoft.Crank.IntegrationTests/AzureWorkerTests.cs
+++ b/test/Microsoft.Crank.IntegrationTests/AzureWorkerTests.cs
@@ -5,7 +5,6 @@
 using System;
 using System.IO;
 using System.Text;
-using System.Reflection;
 using System.Collections.Generic;
 using Microsoft.Crank.AzureDevOpsWorker;
 using Xunit;


### PR DESCRIPTION
This adds support for sending files over Azure Service Bus to the Azure Dev Ops Worker. Changes include adding a <string, string> dictionary for the files to the JobPayload, added the default usage of a temp directory to use as the working directory for these files (including cleanup), and added functionality to materialize base64 files from the JobPayload files dictionary to actual files. 

