### PR TITLE
Update pipeline OS display name from Ubuntu 20.04 to 24.04

### DIFF
--- a/azure-pr-pipelines.yml
+++ b/azure-pr-pipelines.yml
@@ -68,7 +68,7 @@ stages:
             parallel: true
 
       - job: Ubuntu
-        displayName: 'Ubuntu 20.04'
+        displayName: 'Ubuntu 24.04'
         pool:
           vmImage: ubuntu-latest
         variables:


### PR DESCRIPTION
Update pipeline OS display name from Ubuntu 20.04 to 24.04 to reflect the current OS being used in PR testing.