### PR TITLE
docker/agent: install default latest openssl version

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -63,12 +63,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN echo 'deb http://deb.debian.org/debian sid main' >> /etc/apt/sources.list \
     && echo 'deb http://deb.debian.org/debian-debug sid-debug main' >> /etc/apt/sources.list
 
-ENV OPENSSL_VERSION=3.5.*
-# Update package lists and install specific versions of OpenSSL, libssl-dev, and their debug symbols
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        openssl=${OPENSSL_VERSION} libssl-dev=${OPENSSL_VERSION} openssl-dbgsym=${OPENSSL_VERSION} libssl3t64-dbgsym=${OPENSSL_VERSION} \
-    && apt-get clean
+        openssl libssl-dev openssl-dbgsym libssl3t64-dbgsym \
+    && openssl version
 
 # If nghttp2 build fail just ignore it
 ENV NGHTTP2_VERSION=1.58.0


### PR DESCRIPTION
Before we changed the code to install a specific controllable version of openssl due to the perf regression in openssl (3.0.15 was super slow compared to 1.1.1 or 3.2+).

Now since regression is being fixed, we should just target latest openssl version. Moreover, everytime openssl has a new versions, our machines are stuck on update:
> on the step => [stage-1  7/13] RUN apt-get update     && apt-get install -y --no-install-recommends         openssl=3.5.  **15099.8s**

this "install latest" works well, and installes 3.5.4 on my machine on the moment of PR creation
<img width="727" height="73" alt="image" src="https://github.com/user-attachments/assets/f8808e8d-a804-4401-b92e-83483195496e" />
