### PR TITLE
Add cgroup-tools to the AL3 dockerfile and set cgroupns=host for docker run

### DIFF
--- a/docker/agent/Dockerfile.AzureLinux3
+++ b/docker/agent/Dockerfile.AzureLinux3
@@ -26,6 +26,8 @@ RUN tdnf update -y \
         procps-ng \
         curl \
         wget \
+        libcgroup \
+        libcgroup-tools \
         # dotnet performance repo microbenchmark dependencies
         libgdiplus \
         # libmsquic requirements

--- a/docker/agent/run.sh
+++ b/docker/agent/run.sh
@@ -41,9 +41,11 @@ then
 fi
 
 # cgroupfs is mapped to allow docker to create cgroups without permissions issues (cgroup v2)
+# set cgroupns to host to allow the container to share the host's cgroup namespace (matches v1 and v2 namespace modes: https://docs.docker.com/engine/containers/runmetrics/#running-docker-on-cgroup-v2)
 # docker.sock is mapped to be able to manage other docker instances from this one
 docker run -it --name $name -d --network host --restart always \
     --log-opt max-size=1G --privileged \
+    --cgroupns=host \
     -v /sys/fs/cgroup/:/sys/fs/cgroup/ \
     -v /var/run/docker.sock:/var/run/docker.sock $dockerargs \
     crank-agent \


### PR DESCRIPTION
Add cgroup-tools to the AL3 dockerfile to support cgroup tools and setting things like CPUSets and CPULimit. Also add cgroupns=host as a docker run option to run.sh docker run.

Locally testing, this fixes an AL3 cgroup issues we have been hitting where the cgroup would fail to create the group (after installing the tools): `An error occurred trying to start process 'cgcreate' with working directory '/'. No such file or directory`.

cgroupns was added to docker cli in 2020 in version 20.10 (https://docs.docker.com/engine/release-notes/20.10/), so we should be clear to add this option without worrying about out-of-date clients. However, if we are worried about old docker cli instances I can set up the flag to only be added if in the docker help output.