### PR TITLE
fix: handle errors during Ultra installation

### DIFF
--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -4552,9 +4552,8 @@ namespace Microsoft.Crank.Agent
                 {
                     Log.Info($"Timeout trying to download {url}, attempt {i + 1}");
                 }
-                catch (HttpRequestException ex)
+                catch (HttpRequestException)
                 {
-
                     // No need to retry on a 404
                     if (response != null && response.StatusCode == System.Net.HttpStatusCode.NotFound)
                     {


### PR DESCRIPTION
If ultra installation fails, agent just dies:
<img width="1699" height="730" alt="image" src="https://github.com/user-attachments/assets/01e43f06-3c6d-4511-ae11-8fe38b4a56e1" />
 