### PR TITLE
Use official URLs for dotnet release metadata

### DIFF
--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -4483,7 +4483,7 @@ namespace Microsoft.Crank.Agent
         private static async Task<(string Runtime, string Desktop, string AspNet, string Sdk)> GetCurrentVersions(string targetFramework)
         {
             var frameworkVersion = ExtractVersionPrefix(targetFramework); // 6.0
-            var metadataUrl = $"https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/{frameworkVersion}/releases.json";
+            var metadataUrl = $"https://builds.dotnet.microsoft.com/dotnet/release-metadata/{frameworkVersion}/releases.json";
 
             try
             {


### PR DESCRIPTION
The blob storage URLs are deprecated and will stop working at some point, see https://github.com/dotnet/announcements/issues/336