### PR TITLE
Add missing dotnet11 feeds for installing dotnet with dotnet-install.

### DIFF
--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -6248,6 +6248,8 @@ namespace Microsoft.Crank.Agent
                 File.WriteAllText(rootNugetConfig, @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
   <packageSources>
+    <add key=""dotnet11"" value=""https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11/nuget/v3/index.json"" />
+    <add key=""dotnet11-transport"" value=""https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11-transport/nuget/v3/index.json"" />
     <add key=""benchmarks-dotnet10"" value=""https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json"" />
     <add key=""benchmarks-dotnet10-transport"" value=""https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10-transport/nuget/v3/index.json"" />
     <add key=""benchmarks-dotnet9"" value=""https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json"" />


### PR DESCRIPTION
Add missing dotnet11 feeds for installing dotnet with dotnet-install. I expect this to fix errors around `dotnet-install could not install a component: SDK '11.0.100-preview.2.26078.113'`, such as in one of the Build jobs from: https://dev.azure.com/dnceng/internal/_build/results?buildId=2890003&view=results. Even if it does not fix this issue, it seems like an update that should be made as we are working toward net11 runs.