### PR TITLE
Fix agent Docker build failure from sid openssl package conflict

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -66,7 +66,7 @@ RUN echo 'deb http://deb.debian.org/debian sid main' >> /etc/apt/sources.list \
     && echo 'deb http://deb.debian.org/debian-debug sid-debug main' >> /etc/apt/sources.list
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-overwrite" \
         openssl libssl-dev openssl-dbgsym libssl3t64-dbgsym \
     && openssl version
 


### PR DESCRIPTION
The Dockerfile installs OpenSSL packages from Debian sid on a bookworm base image. A recent sid update split legacy.so into a new openssl-provider-legacy package, but that file still belongs to bookworm's libssl3. dpkg fails because it cannot overwrite the file during the cross-repository upgrade.

Adding --force-overwrite to the apt-get install lets dpkg resolve the file ownership transition so the upgrade completes normally.

Tested this fix on one of the broken machines and it fixed the error.

<details><summary>Failure Log</summary>

```

 => ERROR [stage-1  7/14] RUN apt-get update     && apt-get install -y --no-install-recommends         openssl libssl-dev openssl-dbgsym libssl3t64-dbgsym     && open  10.3s
------
 > [stage-1  7/14] RUN apt-get update     && apt-get install -y --no-install-recommends         openssl libssl-dev openssl-dbgsym libssl3t64-dbgsym     && openssl version:
#10 0.570 Hit:1 https://packages.microsoft.com/debian/12/prod bookworm InRelease
#10 0.600 Get:2 http://deb.debian.org/debian sid InRelease [187 kB]
#10 1.051 Get:3 http://deb.debian.org/debian-debug sid-debug InRelease [51.4 kB]
#10 1.121 Hit:4 http://deb.debian.org/debian bookworm InRelease
#10 1.167 Hit:5 http://deb.debian.org/debian bookworm-updates InRelease
#10 1.213 Hit:6 http://deb.debian.org/debian-security bookworm-security InRelease
#10 1.259 Get:7 http://deb.debian.org/debian sid/main amd64 Packages [10.4 MB]
#10 1.702 Get:8 http://deb.debian.org/debian-debug sid-debug/main amd64 Packages [4038 kB]
#10 3.572 Fetched 14.6 MB in 3s (4584 kB/s)
#10 3.572 Reading package lists...
#10 5.195 W: https://packages.microsoft.com/debian/12/prod/dists/bookworm/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
#10 5.212 Reading package lists...
#10 6.660 Building dependency tree...
#10 6.847 Reading state information...
#10 7.069 The following packages were automatically installed and are no longer required:
#10 7.070   libcrypt-dev libnsl-dev libtirpc-dev
#10 7.070 Use 'apt autoremove' to remove them.
#10 7.070 The following additional packages will be installed:
#10 7.071   base-files libc-bin libc-dev-bin libc-gconv-modules-extra libc6 libc6-dev
#10 7.071   libssl3t64 libzstd1 openssl-provider-legacy
#10 7.072 Suggested packages:
#10 7.072   libc-devtools glibc-doc libc-l10n locales libnss-nis libnss-nisplus
#10 7.072   manpages-dev libssl-doc
#10 7.072 Recommended packages:
#10 7.072   manpages manpages-dev
#10 7.177 The following packages will be REMOVED:
#10 7.177   libssl3
#10 7.177 The following NEW packages will be installed:
#10 7.179   libc-gconv-modules-extra libssl-dev libssl3t64 libssl3t64-dbgsym
#10 7.179   openssl-dbgsym openssl-provider-legacy
#10 7.179 The following packages will be upgraded:
#10 7.180   base-files libc-bin libc-dev-bin libc6 libc6-dev libzstd1 openssl
#10 7.226 7 upgraded, 6 newly installed, 1 to remove and 297 not upgraded.
#10 7.226 Need to get 20.4 MB of archives.
#10 7.226 After this operation, 29.1 MB of additional disk space will be used.
#10 7.226 Get:1 http://deb.debian.org/debian sid/main amd64 base-files amd64 14 [72.9 kB]
#10 7.245 Get:2 http://deb.debian.org/debian sid/main amd64 libc-dev-bin amd64 2.42-13 [61.5 kB]
#10 7.259 Get:3 http://deb.debian.org/debian sid/main amd64 libc6-dev amd64 2.42-13 [2016 kB]
#10 7.323 Get:4 http://deb.debian.org/debian sid/main amd64 libc-gconv-modules-extra amd64 2.42-13 [1123 kB]
#10 7.491 Get:5 http://deb.debian.org/debian sid/main amd64 libc6 amd64 2.42-13 [1814 kB]
#10 7.545 Get:6 http://deb.debian.org/debian sid/main amd64 libc-bin amd64 2.42-13 [644 kB]
#10 7.556 Get:7 http://deb.debian.org/debian sid/main amd64 libzstd1 amd64 1.5.7+dfsg-3+b1 [308 kB]
#10 7.560 Get:8 http://deb.debian.org/debian sid/main amd64 openssl-provider-legacy amd64 3.6.1-2 [314 kB]
#10 7.565 Get:9 http://deb.debian.org/debian sid/main amd64 openssl amd64 3.6.1-2 [1513 kB]
#10 7.589 Get:10 http://deb.debian.org/debian sid/main amd64 libssl3t64 amd64 3.6.1-2 [2477 kB]
#10 7.628 Get:11 http://deb.debian.org/debian sid/main amd64 libssl-dev amd64 3.6.1-2 [3015 kB]
#10 7.671 Get:12 http://deb.debian.org/debian-debug sid-debug/main amd64 libssl3t64-dbgsym amd64 3.6.1-2 [6315 kB]
#10 7.761 Get:13 http://deb.debian.org/debian-debug sid-debug/main amd64 openssl-dbgsym amd64 3.6.1-2 [756 kB]
#10 7.934 debconf: delaying package configuration, since apt-utils is not installed
#10 7.999 Fetched 20.4 MB in 1s (35.0 MB/s)
(Reading database ... 21951 files and directories currently installed.)
#10 8.042 Preparing to unpack .../base-files_14_amd64.deb ...
#10 8.093 Unpacking base-files (14) over (12.4+deb12u13) ...
#10 8.162 Setting up base-files (14) ...
#10 8.164 Installing new version of config file /etc/debian_version ...
#10 8.170 Installing new version of config file /etc/issue ...
#10 8.172 Installing new version of config file /etc/issue.net ...
#10 8.193 Updating /etc/profile to current default.
#10 8.203 Updating /root/.profile to current default.
(Reading database ... 21961 files and directories currently installed.)
#10 8.267 Preparing to unpack .../libc-dev-bin_2.42-13_amd64.deb ...
#10 8.272 Unpacking libc-dev-bin (2.42-13) over (2.36-9+deb12u13) ...
#10 8.319 Preparing to unpack .../libc6-dev_2.42-13_amd64.deb ...
#10 8.324 Unpacking libc6-dev:amd64 (2.42-13) over (2.36-9+deb12u13) ...
#10 8.856 Preparing to unpack .../libc6_2.42-13_amd64.deb ...
#10 8.982 Checking for services that may need to be restarted...
#10 9.000 Checking init scripts...
#10 9.055 Unpacking libc6:amd64 (2.42-13) over (2.36-9+deb12u13) ...
#10 9.294 Selecting previously unselected package libc-gconv-modules-extra:amd64.
#10 9.297 Preparing to unpack .../libc-gconv-modules-extra_2.42-13_amd64.deb ...
#10 9.298 Unpacking libc-gconv-modules-extra:amd64 (2.42-13) ...
#10 9.497 Setting up libc-gconv-modules-extra:amd64 (2.42-13) ...
(Reading database ... 21977 files and directories currently installed.)
#10 9.538 Preparing to unpack .../libc-bin_2.42-13_amd64.deb ...
#10 9.541 Unpacking libc-bin (2.42-13) over (2.36-9+deb12u13) ...
#10 9.653 Setting up libc6:amd64 (2.42-13) ...
#10 9.655 Installing new version of config file /etc/ld.so.conf.d/x86_64-linux-gnu.conf ...
#10 9.744 Checking for services that may need to be restarted...
#10 9.761 Checking init scripts...
#10 9.761 Nothing to restart.
#10 9.784 Setting up libc-bin (2.42-13) ...
(Reading database ... 21977 files and directories currently installed.)
#10 9.860 Preparing to unpack .../libzstd1_1.5.7+dfsg-3+b1_amd64.deb ...
#10 9.865 Unpacking libzstd1:amd64 (1.5.7+dfsg-3+b1) over (1.5.4+dfsg2-5) ...
#10 9.932 Setting up libzstd1:amd64 (1.5.7+dfsg-3+b1) ...
#10 9.960 Selecting previously unselected package openssl-provider-legacy.
(Reading database ... 21978 files and directories currently installed.)
#10 9.973 Preparing to unpack .../openssl-provider-legacy_3.6.1-2_amd64.deb ...
#10 9.975 Unpacking openssl-provider-legacy (3.6.1-2) ...
#10 9.984 dpkg: error processing archive /var/cache/apt/archives/openssl-provider-legacy_3.6.1-2_amd64.deb (--unpack):
#10 9.984  trying to overwrite '/usr/lib/x86_64-linux-gnu/ossl-modules/legacy.so', which is also in package libssl3:amd64 3.0.18-1~deb12u2
#10 10.00 Preparing to unpack .../openssl_3.6.1-2_amd64.deb ...
#10 10.00 Unpacking openssl (3.6.1-2) over (3.0.18-1~deb12u2) ...
#10 10.18 Errors were encountered while processing:
#10 10.18  /var/cache/apt/archives/openssl-provider-legacy_3.6.1-2_amd64.deb
#10 10.24 E: Sub-process /usr/bin/dpkg returned an error code (1)
------
executor failed running [/bin/sh -c apt-get update     && apt-get install -y --no-install-recommends         openssl libssl-dev openssl-dbgsym libssl3t64-dbgsym     && openssl version]: exit code: 100
```

</details>