### PR TITLE
Strip version metadata from Results dict when `--no-metadata` is used

### DIFF
--- a/src/Microsoft.Crank.Controller/Program.cs
+++ b/src/Microsoft.Crank.Controller/Program.cs
@@ -2890,6 +2890,18 @@ namespace Microsoft.Crank.Controller
             }
         }
 
+        // Version result keys that are text metadata, not numeric benchmarks.
+        // When stored alongside numeric results they pollute data consumers
+        // (e.g. Power BI) that expect every result key to be a chartable metric.
+        private static readonly string[] VersionResultKeys = new[]
+        {
+            "netCoreAppVersion",
+            "NetCoreAppVersion",
+            "aspNetCoreVersion",
+            "AspNetCoreVersion",
+            "netSdkVersion",
+        };
+
         private static void CleanMeasurements(JobResults jobResults)
         {
             // Remove metadata
@@ -2899,6 +2911,11 @@ namespace Microsoft.Crank.Controller
                 if (_excludeMetadataOption.HasValue())
                 {
                     jobResult.Metadata = Array.Empty<ResultMetadata>();
+
+                    foreach (var key in VersionResultKeys)
+                    {
+                        jobResult.Results.Remove(key);
+                    }
                 }
 
                 // Exclude measurements


### PR DESCRIPTION
## Problem

  The ASP.NET Core benchmarks Power BI dashboard (KPIs page) shows two broken rows: "NETCore App" and "ASP.NET Core" that display raw version strings (e.g. 10.0.5+a612c2a1056f) instead of KPI charts
I was convinced some benchmarks are broken and was looking for failed jobs to fix them, it does not look intentional:

<img width="1885" height="244" alt="image" src="https://github.com/user-attachments/assets/562c6342-1a0c-492f-9d24-702f3c5941a6" />

  These are not real benchmark scenarios. No scenario YAML in aspnet/Benchmarks (https://github.com/aspnet/Benchmarks) defines them. They are phantom rows created when Power BI reads text-valued version entries from the results dictionary in stored JSON.

## Root cause

  The crank Agent registers AspNetCoreVersion and NetCoreAppVersion as measurements (Startup.cs (https://github.com/dotnet/crank/blob/main/src/Microsoft.Crank.Agent/Startup.cs#L3238-L3301)). The Controller's AggregateAndReduceResults() aggregates all measurements — including these text strings — into jobResult.Results.

  The baseline pipelines pass `--no-metadata --no-measurements`, but:
   - `--no-metadata` only clears Metadata[] (the description array)
   - `--no-measurements` only clears Measurements[] (the raw samples)
   - Neither touches Results — the aggregated values persist in the stored JSON

  This has been the case since the initial commit (0347e98, Jul 2020).

  ## Fix

  When `--no-metadata` is active, also remove the well-known version keys from `jobResult.Results`:
   - netCoreAppVersion / NetCoreAppVersion
   - aspNetCoreVersion / AspNetCoreVersion
   - netSdkVersion