### PR TITLE
Add dynamic Azure provisioning for crank profiles

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,10 @@
   <ItemGroup>
     <PackageVersion Include="Azure.Identity" Version="1.15.0" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+    <PackageVersion Include="Azure.ResourceManager" Version="1.13.0" />
+    <PackageVersion Include="Azure.ResourceManager.Compute" Version="1.6.0" />
+    <PackageVersion Include="Azure.ResourceManager.Network" Version="1.9.0" />
+    <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.9.0" />
     <PackageVersion Include="Fluid.Core" Version="2.8.0" />
     <PackageVersion Include="Jint" Version="3.0.0" />
     <PackageVersion Include="JsonSchema.Net" Version="7.3.4" />

--- a/docs/azure_provisioning.md
+++ b/docs/azure_provisioning.md
@@ -1,0 +1,237 @@
+# Dynamic Azure Provisioning
+
+This guide explains how to use crank's dynamic infrastructure provisioning feature to automatically provision Azure VMs for benchmarking, run tests, and tear down infrastructure — all in a single command.
+
+## Overview
+
+Instead of maintaining always-on machines with `crank-agent` installed, you can define a `provision` block in your profile that describes the infrastructure you need. Crank will:
+
+1. **Provision** Azure VMs with `crank-agent` pre-installed
+2. **Wait** for agents to become healthy
+3. **Run** your benchmark scenario
+4. **Tear down** all infrastructure automatically
+
+## Prerequisites
+
+- [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) installed and authenticated (`az login`)
+- An Azure subscription with permission to create VMs
+- `crank` controller tool installed
+
+## Quick Start
+
+### 1. Define a provisioning profile
+
+Add an `azure` profile to your benchmark configuration:
+
+```yaml
+profiles:
+  azure:
+    variables:
+      serverAddress: "{{ serverAddress }}"
+    agents:
+      application:
+        provision:
+          provider: azure
+          vmSize: Standard_D4s_v5
+          os: linux
+          region: eastus2
+          image: ubuntu-22.04
+      load:
+        provision:
+          provider: azure
+          vmSize: Standard_D4s_v5
+          os: linux
+          region: eastus2
+```
+
+### 2. Run with dynamic provisioning
+
+```bash
+crank --config my.benchmarks.yml --scenario hello --profile azure
+```
+
+That's it! Crank will provision VMs, deploy agents, run the benchmark, and clean up.
+
+## Profile Configuration Reference
+
+The `provision` block supports the following properties:
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `provider` | string | `azure` | Cloud provider (currently only `azure`) |
+| `vmSize` | string | `Standard_D4s_v5` | Azure VM SKU |
+| `os` | string | `linux` | Operating system (`linux` or `windows`) |
+| `region` | string | `eastus2` | Azure region |
+| `image` | string | `ubuntu-22.04` | OS image (`ubuntu-22.04`, `ubuntu-24.04`, `windows-2022`, `windows-2025`) |
+| `customImageId` | string | | Custom VM image resource ID (overrides `image`) |
+| `count` | integer | `1` | Number of VM instances |
+| `agentPort` | integer | `5010` | Port for the crank agent |
+| `agentImage` | string | | Docker image containing crank-agent (uses Docker deployment) |
+| `subscriptionId` | string | | Azure subscription ID (uses default if not set) |
+| `resourceGroup` | string | | Custom resource group name (auto-generated if not set) |
+| `spotInstance` | boolean | `false` | Use Azure Spot VMs for cost savings |
+| `tags` | object | | Additional tags for Azure resources |
+
+## CLI Options
+
+| Option | Description |
+|--------|-------------|
+| `--provision-timeout <minutes>` | Maximum wait time for agents to become ready (default: 10) |
+| `--no-teardown` | Skip tearing down infrastructure after the run (for debugging) |
+| `--provision-cleanup <hours>` | Clean up orphaned resource groups older than N hours |
+
+## Examples
+
+### Basic provisioning
+
+```bash
+crank --config hello.benchmarks.yml --scenario hello --profile azure
+```
+
+### With Spot VMs for cost savings
+
+```yaml
+profiles:
+  azure-spot:
+    agents:
+      application:
+        provision:
+          provider: azure
+          vmSize: Standard_D8s_v5
+          os: linux
+          spotInstance: true
+      load:
+        provision:
+          provider: azure
+          vmSize: Standard_D4s_v5
+          os: linux
+          spotInstance: true
+```
+
+### Using a Docker-based agent
+
+```yaml
+profiles:
+  azure-docker:
+    agents:
+      application:
+        provision:
+          provider: azure
+          vmSize: Standard_D4s_v5
+          agentImage: mcr.microsoft.com/dotnet/crank-agent:latest
+```
+
+### With a custom VM image (fastest startup)
+
+```yaml
+profiles:
+  azure-custom:
+    agents:
+      application:
+        provision:
+          provider: azure
+          vmSize: Standard_D4s_v5
+          customImageId: /subscriptions/.../images/crank-agent-ubuntu
+```
+
+### Debugging — keep VMs alive after run
+
+```bash
+crank --config hello.benchmarks.yml --scenario hello --profile azure --no-teardown
+```
+
+### Clean up orphaned resources
+
+If a run crashes and leaves VMs behind:
+
+```bash
+crank --provision-cleanup 2
+```
+
+This deletes all crank-managed resource groups older than 2 hours.
+
+## Mixing static and dynamic profiles
+
+Existing static profiles continue to work unchanged. You can even combine them:
+
+```yaml
+profiles:
+  # Static endpoint (existing infrastructure)
+  lab:
+    agents:
+      application:
+        endpoints:
+          - http://perf-server:5010
+      load:
+        endpoints:
+          - http://perf-client:5010
+
+  # Dynamic Azure provisioning
+  azure:
+    agents:
+      application:
+        provision:
+          provider: azure
+          vmSize: Standard_D4s_v5
+      load:
+        provision:
+          provider: azure
+          vmSize: Standard_D4s_v5
+```
+
+Use `--profile lab` for static infrastructure or `--profile azure` for dynamic.
+
+## Authentication
+
+Dynamic provisioning uses Azure authentication in this order:
+
+1. **Azure CLI** (`az login`) — recommended for local development
+2. **Managed Identity** — for running in Azure VMs or containers
+3. **Environment variables** — `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`
+
+## Cost Considerations
+
+| VM SKU | $/hour | 10-min benchmark cost |
+|--------|--------|-----------------------|
+| Standard_D2s_v5 (2 vCPU) | ~$0.096 | ~$0.016 |
+| Standard_D4s_v5 (4 vCPU) | ~$0.192 | ~$0.032 |
+| Standard_D8s_v5 (8 vCPU) | ~$0.384 | ~$0.064 |
+| Standard_D16s_v5 (16 vCPU) | ~$0.768 | ~$0.128 |
+
+Using Spot VMs can reduce costs by up to 90%.
+
+## Architecture
+
+```
+┌──────────────┐     1. Provision VMs       ┌──────────────────┐
+│   Controller │ ─────────────────────────►  │   Azure ARM API  │
+│   (crank CLI)│                             └──────────────────┘
+│              │     2. Wait for healthy              │
+│              │ ◄─── GET /jobs/info ────────  ┌──────┴──────┐
+│              │                              │ VM + Agent  │
+│              │     3. Submit jobs            │ (crank-agent)│
+│              │ ─── POST /jobs ────────────► │ :5010        │
+│              │                              └──────────────┘
+│              │     4. Collect results
+│              │ ◄─── GET /jobs/{id} ─────
+│              │
+│              │     5. Teardown
+│              │ ─── DELETE Resource Group ─►  Azure ARM API
+└──────────────┘
+```
+
+## Troubleshooting
+
+### Agents not becoming ready
+
+- Increase timeout: `--provision-timeout 15`
+- Check cloud-init logs on the VM: `/var/log/crank-agent-setup.log`
+- Use `--no-teardown` to keep VMs alive for debugging
+
+### Azure quota limits
+
+If you hit VM quota limits, request an increase in the Azure portal or try a different region.
+
+### Orphaned resources
+
+Use `--provision-cleanup 2` to find and delete resource groups left behind by failed runs. All crank-managed resource groups are tagged with `crank-managed-by: crank-controller`.

--- a/docs/azure_provisioning.md
+++ b/docs/azure_provisioning.md
@@ -218,7 +218,20 @@ crank --config hello.benchmarks.yml --scenario hello --profile azure \
 2. If found and agents are healthy → reuse them, extend the TTL
 3. If not found or agents are unhealthy → provision fresh VMs with the pool name
 4. After the run, VMs are kept alive (not torn down) with an auto-delete tag
-5. Expired pools are cleaned up by `--provision-cleanup`
+5. Expired pools are automatically cleaned up at the start of the next provisioned run
+
+### Automatic cleanup
+
+Every time crank runs with dynamic provisioning, it automatically scans for and deletes any crank-managed resource groups that have passed their `auto-delete-after` time. This means expired pools are cleaned up as a side effect of normal usage — no manual intervention needed as long as crank is run periodically.
+
+> **Important:** If crank is not run again after a pool expires, the VMs will continue running in Azure and incurring costs. If you stop using crank or won't run it again for a while, clean up leftover pools manually:
+>
+> ```bash
+> # Delete all crank-managed resources older than 1 hour
+> crank --provision-cleanup 1
+> ```
+>
+> Or delete the resource groups directly in the [Azure Portal](https://portal.azure.com) — they are named `rg-crank-pool-{name}` and tagged with `crank-managed-by: crank-controller`.
 
 ### Cleaning up pools manually
 
@@ -311,4 +324,6 @@ If you hit VM quota limits, request an increase in the Azure portal or try a dif
 
 ### Orphaned resources
 
-Use `--provision-cleanup 2` to find and delete resource groups left behind by failed runs. All crank-managed resource groups are tagged with `crank-managed-by: crank-controller`.
+Expired pools and crashed-run leftovers are automatically cleaned up at the start of each provisioned run. However, if you stop using crank entirely, leftover resource groups will remain in Azure until manually deleted.
+
+Use `--provision-cleanup 2` to find and delete resource groups left behind by failed runs, or delete `rg-crank-*` resource groups in the Azure portal. All crank-managed resource groups are tagged with `crank-managed-by: crank-controller`.

--- a/docs/azure_provisioning.md
+++ b/docs/azure_provisioning.md
@@ -84,6 +84,7 @@ The `provision` block supports the following properties:
 | `--provision-cleanup <hours>` | Clean up orphaned resource groups older than N hours |
 | `--provision-pool <name>` | Name a pool to reuse VMs across consecutive runs |
 | `--provision-pool-ttl <minutes>` | Time to keep a pool alive after the run (default: 30) |
+| `--provision-pool-maxage <hours>` | Maximum pool age before replacing with fresh VMs (default: 24) |
 
 ## Examples
 
@@ -205,12 +206,19 @@ If the pool's VMs are still running and healthy, they're reused instantly (no pr
 
 ### Controlling pool lifetime
 
-By default, pools are kept alive for 30 minutes after the last run. Customize with:
+By default, pools are kept alive for 30 minutes after the last run and replaced with fresh VMs after 24 hours of total age. Customize with:
 
 ```bash
+# Keep pool alive for 60 minutes between runs
 crank --config hello.benchmarks.yml --scenario hello --profile azure \
   --provision-pool my-bench --provision-pool-ttl 60
+
+# Replace pool with fresh VMs after 12 hours instead of 24
+crank --config hello.benchmarks.yml --scenario hello --profile azure \
+  --provision-pool my-bench --provision-pool-maxage 12
 ```
+
+Pools older than `--provision-pool-maxage` are automatically deleted and reprovisioned to avoid issues from long-running VMs (e.g., memory leaks, disk filling up, stale OS state).
 
 ### How it works
 

--- a/docs/azure_provisioning.md
+++ b/docs/azure_provisioning.md
@@ -82,6 +82,8 @@ The `provision` block supports the following properties:
 | `--provision-timeout <minutes>` | Maximum wait time for agents to become ready (default: 10) |
 | `--no-teardown` | Skip tearing down infrastructure after the run (for debugging) |
 | `--provision-cleanup <hours>` | Clean up orphaned resource groups older than N hours |
+| `--provision-pool <name>` | Name a pool to reuse VMs across consecutive runs |
+| `--provision-pool-ttl <minutes>` | Time to keep a pool alive after the run (default: 30) |
 
 ## Examples
 
@@ -182,6 +184,48 @@ crank --provision-cleanup 2
 ```
 
 This deletes all crank-managed resource groups older than 2 hours.
+
+## Reusing VMs with Provision Pools
+
+When running multiple benchmarks in succession with the same profile, you can avoid reprovisioning VMs each time by using **provision pools**. A named pool keeps VMs alive between runs and reuses them if healthy.
+
+### First run — provisions and names the pool
+
+```bash
+crank --config hello.benchmarks.yml --scenario hello --profile azure --provision-pool my-bench
+```
+
+### Subsequent runs — reuses existing VMs
+
+```bash
+crank --config hello.benchmarks.yml --scenario scenario2 --profile azure --provision-pool my-bench
+```
+
+If the pool's VMs are still running and healthy, they're reused instantly (no provisioning delay). The pool's TTL is extended after each run.
+
+### Controlling pool lifetime
+
+By default, pools are kept alive for 30 minutes after the last run. Customize with:
+
+```bash
+crank --config hello.benchmarks.yml --scenario hello --profile azure \
+  --provision-pool my-bench --provision-pool-ttl 60
+```
+
+### How it works
+
+1. On each run, the controller checks Azure for a resource group named `rg-crank-pool-{name}`
+2. If found and agents are healthy → reuse them, extend the TTL
+3. If not found or agents are unhealthy → provision fresh VMs with the pool name
+4. After the run, VMs are kept alive (not torn down) with an auto-delete tag
+5. Expired pools are cleaned up by `--provision-cleanup`
+
+### Cleaning up pools manually
+
+```bash
+# Clean up all pools/resources older than 1 hour
+crank --provision-cleanup 1
+```
 
 ## Mixing static and dynamic profiles
 

--- a/docs/azure_provisioning.md
+++ b/docs/azure_provisioning.md
@@ -67,6 +67,9 @@ The `provision` block supports the following properties:
 | `count` | integer | `1` | Number of VM instances |
 | `agentPort` | integer | `5010` | Port for the crank agent |
 | `agentImage` | string | | Docker image containing crank-agent (uses Docker deployment) |
+| `agentSource` | string | | Git repository URL to clone and build the agent from source |
+| `agentSourceBranch` | string | `main` | Branch, tag, or commit SHA to checkout when building from source |
+| `agentSourceProject` | string | `src/Microsoft.Crank.Agent/...csproj` | Relative path to agent project within the source repo |
 | `subscriptionId` | string | | Azure subscription ID (uses default if not set) |
 | `resourceGroup` | string | | Custom resource group name (auto-generated if not set) |
 | `spotInstance` | boolean | `false` | Use Azure Spot VMs for cost savings |
@@ -119,6 +122,36 @@ profiles:
           provider: azure
           vmSize: Standard_D4s_v5
           agentImage: mcr.microsoft.com/dotnet/crank-agent:latest
+```
+
+### Building the agent from source
+
+Useful for testing agent changes or running a specific commit/branch:
+
+```yaml
+profiles:
+  azure-source:
+    agents:
+      application:
+        provision:
+          provider: azure
+          vmSize: Standard_D4s_v5
+          agentSource: https://github.com/dotnet/crank.git
+          agentSourceBranch: my-feature-branch
+```
+
+You can also specify a commit SHA:
+
+```yaml
+          agentSourceBranch: abc123def456
+```
+
+Or point to a fork with a custom project path:
+
+```yaml
+          agentSource: https://github.com/my-org/custom-crank.git
+          agentSourceBranch: main
+          agentSourceProject: src/MyCustomAgent/MyCustomAgent.csproj
 ```
 
 ### With a custom VM image (fastest startup)

--- a/samples/hello/hello.azure.benchmarks.yml
+++ b/samples/hello/hello.azure.benchmarks.yml
@@ -1,0 +1,111 @@
+imports:
+  - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
+
+jobs:
+  server:
+    sources:
+      crank:
+        repository: https://github.com/dotnet/crank
+        branchOrCommit: main
+    project: crank/samples/hello/hello.csproj
+    readyStateText: Application started.
+
+scenarios:
+  hello:
+    application:
+      job: server
+    load:
+      job: bombardier
+      variables:
+        serverPort: 5000
+        path: /
+
+profiles:
+  # Original local profile (unchanged - backward compatible)
+  local:
+    variables:
+      serverAddress: localhost
+    jobs: 
+      application:
+        endpoints: 
+          - http://localhost:5010
+      load:
+        endpoints: 
+          - http://localhost:5010
+
+  # NEW: Dynamic Azure provisioning profile
+  # Usage: crank --config hello.azure.benchmarks.yml --scenario hello --profile azure
+  azure:
+    variables:
+      serverAddress: "{{ serverAddress }}"
+    agents:
+      application:
+        provision:
+          provider: azure
+          vmSize: Standard_D4s_v5
+          os: linux
+          region: eastus2
+          image: ubuntu-22.04
+          count: 1
+          agentPort: 5010
+      load:
+        provision:
+          provider: azure
+          vmSize: Standard_D4s_v5
+          os: linux
+          region: eastus2
+          count: 1
+          agentPort: 5010
+
+  # Dynamic Azure provisioning with Spot VMs for cost savings
+  azure-spot:
+    variables:
+      serverAddress: "{{ serverAddress }}"
+    agents:
+      application:
+        provision:
+          provider: azure
+          vmSize: Standard_D8s_v5
+          os: linux
+          region: westus2
+          image: ubuntu-24.04
+          count: 1
+          agentPort: 5010
+          spotInstance: true
+          tags:
+            team: perf-testing
+            environment: ci
+      load:
+        provision:
+          provider: azure
+          vmSize: Standard_D4s_v5
+          os: linux
+          region: westus2
+          image: ubuntu-24.04
+          count: 1
+          agentPort: 5010
+          spotInstance: true
+
+  # Dynamic provisioning using a custom Docker-based agent image
+  azure-docker:
+    variables:
+      serverAddress: "{{ serverAddress }}"
+    agents:
+      application:
+        provision:
+          provider: azure
+          vmSize: Standard_D4s_v5
+          os: linux
+          region: eastus2
+          count: 1
+          agentPort: 5010
+          agentImage: mcr.microsoft.com/dotnet/crank-agent:latest
+      load:
+        provision:
+          provider: azure
+          vmSize: Standard_D4s_v5
+          os: linux
+          region: eastus2
+          count: 1
+          agentPort: 5010
+          agentImage: mcr.microsoft.com/dotnet/crank-agent:latest

--- a/samples/hello/hello.azure.benchmarks.yml
+++ b/samples/hello/hello.azure.benchmarks.yml
@@ -109,3 +109,30 @@ profiles:
           count: 1
           agentPort: 5010
           agentImage: mcr.microsoft.com/dotnet/crank-agent:latest
+
+  # Dynamic provisioning with agent built from source
+  # Useful for testing agent changes or running a specific commit
+  azure-source:
+    variables:
+      serverAddress: "{{ serverAddress }}"
+    agents:
+      application:
+        provision:
+          provider: azure
+          vmSize: Standard_D4s_v5
+          os: linux
+          region: eastus2
+          count: 1
+          agentPort: 5010
+          agentSource: https://github.com/dotnet/crank.git
+          agentSourceBranch: main
+      load:
+        provision:
+          provider: azure
+          vmSize: Standard_D4s_v5
+          os: linux
+          region: eastus2
+          count: 1
+          agentPort: 5010
+          agentSource: https://github.com/dotnet/crank.git
+          agentSourceBranch: main

--- a/src/Microsoft.Crank.Controller/Microsoft.Crank.Controller.csproj
+++ b/src/Microsoft.Crank.Controller/Microsoft.Crank.Controller.csproj
@@ -15,6 +15,10 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.ResourceManager" />
+    <PackageReference Include="Azure.ResourceManager.Compute" />
+    <PackageReference Include="Azure.ResourceManager.Network" />
+    <PackageReference Include="Azure.ResourceManager.Resources" />
     <PackageReference Include="Fluid.Core" />
     <PackageReference Include="Jint" />
     <PackageReference Include="JsonSchema.Net" />

--- a/src/Microsoft.Crank.Controller/Program.cs
+++ b/src/Microsoft.Crank.Controller/Program.cs
@@ -642,7 +642,23 @@ namespace Microsoft.Crank.Controller
 
                     var subscriptionId = provisioningConfigs.Values.FirstOrDefault(c => !string.IsNullOrEmpty(c.SubscriptionId))?.SubscriptionId;
                     var credential = new global::Azure.Identity.DefaultAzureCredential();
-                    provisioner = new AzureProvisioner(credential, subscriptionId);
+                    var azureProvisioner = new AzureProvisioner(credential, subscriptionId);
+                    provisioner = azureProvisioner;
+
+                    // Auto-clean expired pools/resources before provisioning.
+                    // This ensures orphaned VMs from previous runs don't accumulate costs.
+                    try
+                    {
+                        var cleaned = await azureProvisioner.CleanupExpiredResourcesAsync();
+                        if (cleaned > 0)
+                        {
+                            Log.Write($"Auto-cleaned {cleaned} expired resource group(s).");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.WriteWarning($"Auto-cleanup of expired resources failed (non-fatal): {ex.Message}");
+                    }
 
                     // Check for existing pool if --provision-pool is specified
                     if (!string.IsNullOrEmpty(poolName))

--- a/src/Microsoft.Crank.Controller/Program.cs
+++ b/src/Microsoft.Crank.Controller/Program.cs
@@ -98,7 +98,9 @@ namespace Microsoft.Crank.Controller
             _managedIdentityClientId,
             _provisionTimeoutOption,
             _noTeardownOption,
-            _provisionCleanupOption
+            _provisionCleanupOption,
+            _provisionPoolOption,
+            _provisionPoolTtlOption
             ;
 
         private static CommandOption<ValueTuple<string, JToken>>
@@ -219,6 +221,8 @@ namespace Microsoft.Crank.Controller
             _provisionTimeoutOption = app.Option("--provision-timeout", "Maximum time in minutes to wait for dynamically provisioned agents to become ready. Default is 10.", CommandOptionType.SingleValue);
             _noTeardownOption = app.Option("--no-teardown", "Skip tearing down dynamically provisioned infrastructure after the benchmark completes. Useful for debugging.", CommandOptionType.NoValue);
             _provisionCleanupOption = app.Option("--provision-cleanup", "Clean up orphaned provisioned resource groups older than the specified number of hours. e.g., '--provision-cleanup 2'", CommandOptionType.SingleValue);
+            _provisionPoolOption = app.Option("--provision-pool", "Name a provision pool to reuse VMs across consecutive runs. VMs are kept alive and reused if a matching pool is found.", CommandOptionType.SingleValue);
+            _provisionPoolTtlOption = app.Option("--provision-pool-ttl", "Time in minutes to keep a provision pool alive after the run completes. Default is 30.", CommandOptionType.SingleValue);
 
             _ignoredCommands = new HashSet<CommandOption>()
             {
@@ -605,6 +609,11 @@ namespace Microsoft.Crank.Controller
 
                 IInfrastructureProvisioner provisioner = null;
                 IReadOnlyList<ProvisionedAgent> provisionedAgents = null;
+                var poolName = _provisionPoolOption.HasValue() ? _provisionPoolOption.Value() : null;
+                var poolTtl = _provisionPoolTtlOption.HasValue()
+                    ? TimeSpan.FromMinutes(double.Parse(_provisionPoolTtlOption.Value()))
+                    : TimeSpan.FromMinutes(30);
+                var reusedPool = false;
 
                 try
                 {
@@ -635,20 +644,55 @@ namespace Microsoft.Crank.Controller
                     var credential = new global::Azure.Identity.DefaultAzureCredential();
                     provisioner = new AzureProvisioner(credential, subscriptionId);
 
-                    // Provision infrastructure
-                    provisionedAgents = await provisioner.ProvisionAsync(session, provisioningConfigs);
-
-                    // Wait for agents to become ready
-                    var provisionTimeout = _provisionTimeoutOption.HasValue()
-                        ? TimeSpan.FromMinutes(double.Parse(_provisionTimeoutOption.Value()))
-                        : TimeSpan.FromMinutes(10);
-
-                    var allReady = await provisioner.WaitForAgentsReadyAsync(provisionedAgents, provisionTimeout);
-
-                    if (!allReady)
+                    // Check for existing pool if --provision-pool is specified
+                    if (!string.IsNullOrEmpty(poolName))
                     {
-                        Log.WriteError("Not all provisioned agents became ready within the timeout. Aborting.");
-                        return -1;
+                        Log.Write($"Checking for existing provision pool '{poolName}'...");
+                        var existingAgents = await provisioner.FindExistingPoolAsync(poolName, provisioningConfigs);
+
+                        if (existingAgents != null)
+                        {
+                            // Verify agents are still healthy
+                            var healthTimeout = TimeSpan.FromMinutes(2);
+                            var healthy = await provisioner.WaitForAgentsReadyAsync(existingAgents, healthTimeout);
+
+                            if (healthy)
+                            {
+                                Log.Write($"Reusing existing pool '{poolName}' with {existingAgents.Count} healthy agent(s).");
+                                provisionedAgents = existingAgents;
+                                reusedPool = true;
+
+                                // Extend the TTL since we're reusing
+                                await provisioner.ExtendPoolTtlAsync(poolName, poolTtl);
+                            }
+                            else
+                            {
+                                Log.WriteWarning($"Existing pool '{poolName}' has unhealthy agents. Provisioning fresh.");
+                            }
+                        }
+                    }
+
+                    // Provision new infrastructure if we didn't reuse a pool
+                    if (provisionedAgents == null)
+                    {
+                        provisionedAgents = await ((AzureProvisioner)provisioner).ProvisionAsync(
+                            session, provisioningConfigs, poolName, poolTtl);
+                    }
+
+                    // Wait for agents to become ready (if newly provisioned)
+                    if (!reusedPool)
+                    {
+                        var provisionTimeout = _provisionTimeoutOption.HasValue()
+                            ? TimeSpan.FromMinutes(double.Parse(_provisionTimeoutOption.Value()))
+                            : TimeSpan.FromMinutes(10);
+
+                        var allReady = await provisioner.WaitForAgentsReadyAsync(provisionedAgents, provisionTimeout);
+
+                        if (!allReady)
+                        {
+                            Log.WriteError("Not all provisioned agents became ready within the timeout. Aborting.");
+                            return -1;
+                        }
                     }
 
                     // Inject provisioned endpoints into job configuration
@@ -680,10 +724,14 @@ namespace Microsoft.Crank.Controller
                     {
                         e.Cancel = true; // Prevent immediate exit
                         Log.WriteWarning("Ctrl+C detected. Tearing down provisioned infrastructure...");
-                        if (provisioner != null && !_noTeardownOption.HasValue())
+                        if (provisioner != null && !_noTeardownOption.HasValue() && string.IsNullOrEmpty(poolName))
                         {
                             await provisioner.TeardownAsync(session);
                             Log.Write("Emergency teardown complete.");
+                        }
+                        else if (!string.IsNullOrEmpty(poolName))
+                        {
+                            Log.Write($"Pool '{poolName}' will be kept alive (TTL: {poolTtl.TotalMinutes}m). Use --provision-cleanup to remove.");
                         }
                     };
                 }
@@ -857,20 +905,33 @@ namespace Microsoft.Crank.Controller
                 } // end try for provisioning
                 finally
                 {
-                    // Tear down provisioned infrastructure
-                    if (provisioner != null && provisionedAgents != null && !_noTeardownOption.HasValue())
+                    // Tear down provisioned infrastructure (unless using a pool or --no-teardown)
+                    if (provisioner != null && provisionedAgents != null)
                     {
-                        Log.Write("Tearing down provisioned infrastructure...");
-                        await provisioner.TeardownAsync(session);
-                        Log.Write("Infrastructure teardown complete.");
-                    }
-                    else if (_noTeardownOption.HasValue() && provisionedAgents != null)
-                    {
-                        Log.WriteWarning("Skipping infrastructure teardown (--no-teardown specified).");
-                        Log.WriteWarning("Remember to manually delete the provisioned resource groups when done.");
-                        foreach (var agent in provisionedAgents)
+                        if (!string.IsNullOrEmpty(poolName))
                         {
-                            Log.Write($"  Resource group: {agent.ResourceGroupName}, VM: {agent.VmName}, IP: {agent.IpAddress}", notime: true);
+                            // Pool mode: keep infrastructure alive, just extend TTL
+                            Log.Write($"Pool '{poolName}' will remain active for {poolTtl.TotalMinutes} minutes.");
+                            Log.Write("Reuse with: --provision-pool " + poolName);
+                            foreach (var agent in provisionedAgents)
+                            {
+                                Log.Write($"  {agent.ServiceName}: {agent.EndpointUri} (VM: {agent.VmName})", notime: true);
+                            }
+                        }
+                        else if (!_noTeardownOption.HasValue())
+                        {
+                            Log.Write("Tearing down provisioned infrastructure...");
+                            await provisioner.TeardownAsync(session);
+                            Log.Write("Infrastructure teardown complete.");
+                        }
+                        else
+                        {
+                            Log.WriteWarning("Skipping infrastructure teardown (--no-teardown specified).");
+                            Log.WriteWarning("Remember to manually delete the provisioned resource groups when done.");
+                            foreach (var agent in provisionedAgents)
+                            {
+                                Log.Write($"  Resource group: {agent.ResourceGroupName}, VM: {agent.VmName}, IP: {agent.IpAddress}", notime: true);
+                            }
                         }
                     }
 

--- a/src/Microsoft.Crank.Controller/Program.cs
+++ b/src/Microsoft.Crank.Controller/Program.cs
@@ -100,7 +100,8 @@ namespace Microsoft.Crank.Controller
             _noTeardownOption,
             _provisionCleanupOption,
             _provisionPoolOption,
-            _provisionPoolTtlOption
+            _provisionPoolTtlOption,
+            _provisionPoolMaxAgeOption
             ;
 
         private static CommandOption<ValueTuple<string, JToken>>
@@ -223,6 +224,7 @@ namespace Microsoft.Crank.Controller
             _provisionCleanupOption = app.Option("--provision-cleanup", "Clean up orphaned provisioned resource groups older than the specified number of hours. e.g., '--provision-cleanup 2'", CommandOptionType.SingleValue);
             _provisionPoolOption = app.Option("--provision-pool", "Name a provision pool to reuse VMs across consecutive runs. VMs are kept alive and reused if a matching pool is found.", CommandOptionType.SingleValue);
             _provisionPoolTtlOption = app.Option("--provision-pool-ttl", "Time in minutes to keep a provision pool alive after the run completes. Default is 30.", CommandOptionType.SingleValue);
+            _provisionPoolMaxAgeOption = app.Option("--provision-pool-maxage", "Maximum age in hours for a provision pool before it is replaced with fresh VMs. Default is 24.", CommandOptionType.SingleValue);
 
             _ignoredCommands = new HashSet<CommandOption>()
             {
@@ -613,6 +615,9 @@ namespace Microsoft.Crank.Controller
                 var poolTtl = _provisionPoolTtlOption.HasValue()
                     ? TimeSpan.FromMinutes(double.Parse(_provisionPoolTtlOption.Value()))
                     : TimeSpan.FromMinutes(30);
+                var poolMaxAge = _provisionPoolMaxAgeOption.HasValue()
+                    ? TimeSpan.FromHours(double.Parse(_provisionPoolMaxAgeOption.Value()))
+                    : TimeSpan.FromHours(24);
                 var reusedPool = false;
 
                 try
@@ -664,7 +669,7 @@ namespace Microsoft.Crank.Controller
                     if (!string.IsNullOrEmpty(poolName))
                     {
                         Log.Write($"Checking for existing provision pool '{poolName}'...");
-                        var existingAgents = await provisioner.FindExistingPoolAsync(poolName, provisioningConfigs);
+                        var existingAgents = await ((AzureProvisioner)provisioner).FindExistingPoolAsync(poolName, provisioningConfigs, poolMaxAge);
 
                         if (existingAgents != null)
                         {

--- a/src/Microsoft.Crank.Controller/Program.cs
+++ b/src/Microsoft.Crank.Controller/Program.cs
@@ -24,6 +24,7 @@ using Jint.Runtime;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Azure.Relay;
 using Microsoft.Crank.Controller.Serializers;
+using Microsoft.Crank.Controller.Provisioning;
 using Microsoft.Crank.Models;
 using Microsoft.Crank.Models.Security;
 using Newtonsoft.Json;
@@ -94,7 +95,10 @@ namespace Microsoft.Crank.Controller
             _certTenantId,
             _certThumbprint,
             _certSniAuth,
-            _managedIdentityClientId
+            _managedIdentityClientId,
+            _provisionTimeoutOption,
+            _noTeardownOption,
+            _provisionCleanupOption
             ;
 
         private static CommandOption<ValueTuple<string, JToken>>
@@ -212,6 +216,9 @@ namespace Microsoft.Crank.Controller
             _certPassword = app.Option("--cert-pwd", "Password of the certificate to be used for auth.", CommandOptionType.SingleValue);
             _certSniAuth = app.Option("--cert-sni", "Enable subject name / issuer based authentication (SNI).", CommandOptionType.NoValue);
             _managedIdentityClientId = app.Option("--mi-client-id", "Client ID of the user-assigned managed identity to use for authentication.", CommandOptionType.SingleValue);
+            _provisionTimeoutOption = app.Option("--provision-timeout", "Maximum time in minutes to wait for dynamically provisioned agents to become ready. Default is 10.", CommandOptionType.SingleValue);
+            _noTeardownOption = app.Option("--no-teardown", "Skip tearing down dynamically provisioned infrastructure after the benchmark completes. Useful for debugging.", CommandOptionType.NoValue);
+            _provisionCleanupOption = app.Option("--provision-cleanup", "Clean up orphaned provisioned resource groups older than the specified number of hours. e.g., '--provision-cleanup 2'", CommandOptionType.SingleValue);
 
             _ignoredCommands = new HashSet<CommandOption>()
             {
@@ -241,7 +248,10 @@ namespace Microsoft.Crank.Controller
                 _certTenantId,
                 _certThumbprint,
                 _certSniAuth,
-                _managedIdentityClientId
+                _managedIdentityClientId,
+                _provisionTimeoutOption,
+                _noTeardownOption,
+                _provisionCleanupOption
             };
 
             app.Command("compare", compareCmd =>
@@ -588,6 +598,96 @@ namespace Microsoft.Crank.Controller
 
                 string groupId = Guid.NewGuid().ToString("n");
 
+                // === Dynamic Infrastructure Provisioning ===
+                // If any services in the profile use "provision" blocks instead of static "endpoints",
+                // we provision Azure VMs, deploy crank-agents, wait for readiness, then inject the
+                // resulting endpoint URIs into the job configuration before proceeding.
+
+                IInfrastructureProvisioner provisioner = null;
+                IReadOnlyList<ProvisionedAgent> provisionedAgents = null;
+
+                try
+                {
+
+                // Check for provisioning cleanup command
+                if (_provisionCleanupOption.HasValue())
+                {
+                    var cleanupHours = double.Parse(_provisionCleanupOption.Value());
+                    var credential = new global::Azure.Identity.DefaultAzureCredential();
+                    await using var cleanupProvisioner = new AzureProvisioner(credential);
+                    var cleaned = await cleanupProvisioner.CleanupOrphanedResourcesAsync(TimeSpan.FromHours(cleanupHours));
+                    Log.Write($"Cleaned up {cleaned} orphaned resource group(s).");
+
+                    if (!_scenarioOption.HasValue() && !_jobOption.HasValue())
+                    {
+                        return 0;
+                    }
+                }
+
+                // Detect provisioning needs from the merged profile
+                var provisioningConfigs = DetectProvisioningConfigs(configuration, dependencies, _profileOption.Values);
+
+                if (provisioningConfigs.Count > 0)
+                {
+                    Log.Write($"Detected dynamic provisioning for {provisioningConfigs.Count} service(s): {string.Join(", ", provisioningConfigs.Keys)}");
+
+                    var subscriptionId = provisioningConfigs.Values.FirstOrDefault(c => !string.IsNullOrEmpty(c.SubscriptionId))?.SubscriptionId;
+                    var credential = new global::Azure.Identity.DefaultAzureCredential();
+                    provisioner = new AzureProvisioner(credential, subscriptionId);
+
+                    // Provision infrastructure
+                    provisionedAgents = await provisioner.ProvisionAsync(session, provisioningConfigs);
+
+                    // Wait for agents to become ready
+                    var provisionTimeout = _provisionTimeoutOption.HasValue()
+                        ? TimeSpan.FromMinutes(double.Parse(_provisionTimeoutOption.Value()))
+                        : TimeSpan.FromMinutes(10);
+
+                    var allReady = await provisioner.WaitForAgentsReadyAsync(provisionedAgents, provisionTimeout);
+
+                    if (!allReady)
+                    {
+                        Log.WriteError("Not all provisioned agents became ready within the timeout. Aborting.");
+                        return -1;
+                    }
+
+                    // Inject provisioned endpoints into job configuration
+                    foreach (var agent in provisionedAgents)
+                    {
+                        if (configuration.Jobs.TryGetValue(agent.ServiceName, out var job))
+                        {
+                            job.Endpoints.Add(agent.EndpointUri.ToString());
+                            Log.Write($"Injected endpoint {agent.EndpointUri} for service '{agent.ServiceName}'");
+                        }
+                    }
+
+                    // Set serverAddress variable to the first application agent's IP if available
+                    var applicationAgent = provisionedAgents.FirstOrDefault(a => a.ServiceName == "application");
+                    if (applicationAgent != null)
+                    {
+                        foreach (var jobName in dependencies)
+                        {
+                            var job = configuration.Jobs[jobName];
+                            if (job.Variables == null)
+                            {
+                                job.Variables = new JObject();
+                            }
+                            job.Variables["serverAddress"] = applicationAgent.IpAddress;
+                        }
+                    }
+                    // Register Ctrl+C handler to ensure teardown on interruption
+                    Console.CancelKeyPress += async (sender, e) =>
+                    {
+                        e.Cancel = true; // Prevent immediate exit
+                        Log.WriteWarning("Ctrl+C detected. Tearing down provisioned infrastructure...");
+                        if (provisioner != null && !_noTeardownOption.HasValue())
+                        {
+                            await provisioner.TeardownAsync(session);
+                            Log.Write("Emergency teardown complete.");
+                        }
+                    };
+                }
+
                 // Verifying jobs
                 foreach (var jobName in dependencies)
                 {
@@ -753,6 +853,32 @@ namespace Microsoft.Crank.Controller
                 }
 
                 return results.ReturnCode;
+
+                } // end try for provisioning
+                finally
+                {
+                    // Tear down provisioned infrastructure
+                    if (provisioner != null && provisionedAgents != null && !_noTeardownOption.HasValue())
+                    {
+                        Log.Write("Tearing down provisioned infrastructure...");
+                        await provisioner.TeardownAsync(session);
+                        Log.Write("Infrastructure teardown complete.");
+                    }
+                    else if (_noTeardownOption.HasValue() && provisionedAgents != null)
+                    {
+                        Log.WriteWarning("Skipping infrastructure teardown (--no-teardown specified).");
+                        Log.WriteWarning("Remember to manually delete the provisioned resource groups when done.");
+                        foreach (var agent in provisionedAgents)
+                        {
+                            Log.Write($"  Resource group: {agent.ResourceGroupName}, VM: {agent.VmName}, IP: {agent.IpAddress}", notime: true);
+                        }
+                    }
+
+                    if (provisioner != null)
+                    {
+                        await provisioner.DisposeAsync();
+                    }
+                }
             });
 
             try
@@ -2486,6 +2612,51 @@ namespace Microsoft.Crank.Controller
                     source["localFolder"] = resolvedFilename;
                 }
             }
+        }
+
+        /// <summary>
+        /// Detects provisioning configurations from the merged profile for the current scenario.
+        /// Returns a dictionary of service name → ProvisioningConfig for services that need 
+        /// dynamic infrastructure provisioning.
+        /// </summary>
+        private static Dictionary<string, ProvisioningConfig> DetectProvisioningConfigs(
+            Configuration configuration,
+            string[] dependencies,
+            IList<string> profileNames)
+        {
+            if (profileNames == null || !profileNames.Any())
+            {
+                return new Dictionary<string, ProvisioningConfig>();
+            }
+
+            // Re-load the raw profile JObject to inspect for provision blocks.
+            // The Configuration class doesn't parse provision blocks, so we need to
+            // look at the raw profile data.
+            var mergedProfile = new JObject();
+
+            foreach (var profileName in profileNames)
+            {
+                if (string.IsNullOrEmpty(profileName) || !configuration.Profiles.ContainsKey(profileName))
+                {
+                    continue;
+                }
+
+                // The Profiles dictionary stores the raw deserialized data
+                var profileData = configuration.Profiles[profileName];
+                if (profileData is JObject profileJObject)
+                {
+                    PatchObject(mergedProfile, profileJObject);
+                }
+                else
+                {
+                    // Try to convert via JSON serialization
+                    var json = JsonConvert.SerializeObject(profileData);
+                    var jobj = JObject.Parse(json);
+                    PatchObject(mergedProfile, jobj);
+                }
+            }
+
+            return ProvisioningConfigParser.ExtractProvisioningConfigs(mergedProfile, dependencies);
         }
 
         /// <summary>

--- a/src/Microsoft.Crank.Controller/Provisioning/AzureProvisioner.cs
+++ b/src/Microsoft.Crank.Controller/Provisioning/AzureProvisioner.cs
@@ -305,6 +305,18 @@ namespace Microsoft.Crank.Controller.Provisioning
             IDictionary<string, ProvisioningConfig> agentConfigs,
             CancellationToken cancellationToken = default)
         {
+            return await FindExistingPoolAsync(poolName, agentConfigs, maxPoolAge: null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Searches for an existing pool, rejecting it if it exceeds the maximum age.
+        /// </summary>
+        public async Task<IReadOnlyList<ProvisionedAgent>> FindExistingPoolAsync(
+            string poolName,
+            IDictionary<string, ProvisioningConfig> agentConfigs,
+            TimeSpan? maxPoolAge,
+            CancellationToken cancellationToken = default)
+        {
             var subscription = await GetSubscriptionAsync(cancellationToken);
             var expectedRgName = $"{ResourceGroupPrefix}pool-{poolName}";
 
@@ -343,6 +355,32 @@ namespace Microsoft.Crank.Controller.Provisioning
             {
                 Log.Write($"Pool '{poolName}' has expired (auto-delete was {autoDeleteAt:u}). Will provision fresh.");
                 return null;
+            }
+
+            // Check if pool exceeds max age (default: 24 hours)
+            if (resourceGroup.Data.Tags.TryGetValue(TagCreatedAt, out var createdAtStr)
+                && DateTime.TryParse(createdAtStr, out var poolCreatedAt))
+            {
+                var poolAge = DateTime.UtcNow - poolCreatedAt;
+                var maxAge = maxPoolAge ?? TimeSpan.FromHours(24);
+
+                if (poolAge > maxAge)
+                {
+                    Log.Write($"Pool '{poolName}' is {poolAge.TotalHours:F1} hours old (max: {maxAge.TotalHours:F1}h). Will provision fresh.");
+                    // Initiate deletion of the stale pool
+                    try
+                    {
+                        await resourceGroup.DeleteAsync(WaitUntil.Started, cancellationToken: cancellationToken);
+                        Log.Write($"Initiated deletion of stale pool resource group '{expectedRgName}'.");
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.WriteWarning($"Failed to delete stale pool '{expectedRgName}': {ex.Message}");
+                    }
+                    return null;
+                }
+
+                Log.Write($"Pool '{poolName}' age: {poolAge.TotalHours:F1} hours (max: {maxAge.TotalHours:F1}h).");
             }
 
             // Discover VMs and build ProvisionedAgent list from existing resources

--- a/src/Microsoft.Crank.Controller/Provisioning/AzureProvisioner.cs
+++ b/src/Microsoft.Crank.Controller/Provisioning/AzureProvisioner.cs
@@ -1,0 +1,679 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Core;
+using Azure.Identity;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Compute;
+using Azure.ResourceManager.Compute.Models;
+using Azure.ResourceManager.Network;
+using Azure.ResourceManager.Network.Models;
+using Azure.ResourceManager.Resources;
+using AzureLocation = Azure.Core.AzureLocation;
+
+namespace Microsoft.Crank.Controller.Provisioning
+{
+    /// <summary>
+    /// Provisions Azure VMs with crank-agent installed and running.
+    /// Uses Azure Resource Manager SDK for VM lifecycle management.
+    /// </summary>
+    public class AzureProvisioner : IInfrastructureProvisioner
+    {
+        private const string ResourceGroupPrefix = "rg-crank-";
+        private const string TagSessionId = "crank-session";
+        private const string TagCreatedAt = "crank-created-at";
+        private const string TagAutoDeleteAfter = "crank-auto-delete-after";
+        private const string TagManagedBy = "crank-managed-by";
+
+        private static readonly TimeSpan DefaultAutoDeleteAfter = TimeSpan.FromHours(2);
+
+        private readonly ArmClient _armClient;
+        private readonly SubscriptionResource _subscription;
+        private readonly HttpClient _httpClient;
+        private readonly Dictionary<string, string> _sessionResourceGroups = new();
+
+        public AzureProvisioner(TokenCredential credential, string subscriptionId = null)
+        {
+            _armClient = new ArmClient(credential);
+
+            if (!string.IsNullOrEmpty(subscriptionId))
+            {
+                _subscription = _armClient.GetSubscriptionResource(
+                    SubscriptionResource.CreateResourceIdentifier(subscriptionId));
+            }
+
+            var handler = new HttpClientHandler
+            {
+                ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+            };
+            _httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(10) };
+        }
+
+        /// <inheritdoc/>
+        public async Task<IReadOnlyList<ProvisionedAgent>> ProvisionAsync(
+            string sessionId,
+            IDictionary<string, ProvisioningConfig> agentConfigs,
+            CancellationToken cancellationToken = default)
+        {
+            var agents = new List<ProvisionedAgent>();
+            var subscription = await GetSubscriptionAsync(cancellationToken);
+
+            // Group agents by resource group (use shared RG or per-session)
+            var resourceGroupName = agentConfigs.Values.FirstOrDefault()?.ResourceGroup
+                ?? $"{ResourceGroupPrefix}{sessionId}";
+
+            _sessionResourceGroups[sessionId] = resourceGroupName;
+
+            // Determine the region from the first config (all VMs in same RG share region)
+            var region = agentConfigs.Values.First().Region;
+
+            Log.Write($"Provisioning infrastructure in resource group '{resourceGroupName}' in region '{region}'...");
+
+            // Create resource group
+            var rgData = new ResourceGroupData(new AzureLocation(region));
+            rgData.Tags.Add(TagSessionId, sessionId);
+            rgData.Tags.Add(TagCreatedAt, DateTime.UtcNow.ToString("o"));
+            rgData.Tags.Add(TagAutoDeleteAfter, DateTime.UtcNow.Add(DefaultAutoDeleteAfter).ToString("o"));
+            rgData.Tags.Add(TagManagedBy, "crank-controller");
+
+            var rgCollection = subscription.GetResourceGroups();
+            var rgOperation = await rgCollection.CreateOrUpdateAsync(
+                WaitUntil.Completed, resourceGroupName, rgData, cancellationToken);
+            var resourceGroup = rgOperation.Value;
+
+            Log.Write($"Resource group '{resourceGroupName}' created.");
+
+            // Create shared networking resources
+            var (vnet, nsg) = await CreateNetworkingAsync(resourceGroup, region, agentConfigs, cancellationToken);
+
+            // Provision VMs for each service in parallel
+            var provisionTasks = new List<Task<List<ProvisionedAgent>>>();
+
+            foreach (var (serviceName, config) in agentConfigs)
+            {
+                provisionTasks.Add(ProvisionServiceVmsAsync(
+                    resourceGroup, vnet, nsg, serviceName, config, region, sessionId, cancellationToken));
+            }
+
+            var results = await Task.WhenAll(provisionTasks);
+
+            foreach (var result in results)
+            {
+                agents.AddRange(result);
+            }
+
+            Log.Write($"Provisioned {agents.Count} agent(s) across {agentConfigs.Count} service(s).");
+            return agents;
+        }
+
+        /// <inheritdoc/>
+        public async Task TeardownAsync(string sessionId, CancellationToken cancellationToken = default)
+        {
+            if (!_sessionResourceGroups.TryGetValue(sessionId, out var resourceGroupName))
+            {
+                Log.Write($"No resource group found for session '{sessionId}', skipping teardown.");
+                return;
+            }
+
+            try
+            {
+                var subscription = await GetSubscriptionAsync(cancellationToken);
+                var rgResource = subscription.GetResourceGroups()
+                    .GetIfExists(resourceGroupName, cancellationToken)?.Value;
+
+                if (rgResource != null)
+                {
+                    Log.Write($"Tearing down resource group '{resourceGroupName}'...");
+                    await rgResource.DeleteAsync(WaitUntil.Started, cancellationToken: cancellationToken);
+                    Log.Write($"Resource group '{resourceGroupName}' deletion initiated.");
+                }
+                else
+                {
+                    Log.Write($"Resource group '{resourceGroupName}' not found, nothing to tear down.");
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.WriteWarning($"Warning: Failed to tear down resource group '{resourceGroupName}': {ex.Message}");
+            }
+            finally
+            {
+                _sessionResourceGroups.Remove(sessionId);
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task<bool> WaitForAgentsReadyAsync(
+            IReadOnlyList<ProvisionedAgent> agents,
+            TimeSpan timeout,
+            CancellationToken cancellationToken = default)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            var retryDelay = TimeSpan.FromSeconds(5);
+            var maxRetryDelay = TimeSpan.FromSeconds(30);
+
+            var pendingAgents = new HashSet<ProvisionedAgent>(agents);
+
+            while (pendingAgents.Count > 0 && DateTime.UtcNow < deadline)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var checkTasks = pendingAgents.Select(async agent =>
+                {
+                    try
+                    {
+                        var response = await _httpClient.GetAsync(
+                            new Uri(agent.EndpointUri, "/jobs/info"), cancellationToken);
+
+                        if (response.IsSuccessStatusCode)
+                        {
+                            return (agent, ready: true);
+                        }
+                    }
+                    catch
+                    {
+                        // Agent not ready yet
+                    }
+
+                    return (agent, ready: false);
+                }).ToList();
+
+                var results = await Task.WhenAll(checkTasks);
+
+                foreach (var (agent, ready) in results)
+                {
+                    if (ready)
+                    {
+                        Log.Write($"Agent '{agent.ServiceName}' at {agent.EndpointUri} is ready.");
+                        pendingAgents.Remove(agent);
+                    }
+                }
+
+                if (pendingAgents.Count > 0)
+                {
+                    var remaining = deadline - DateTime.UtcNow;
+                    Log.Write($"Waiting for {pendingAgents.Count} agent(s) to become ready... ({remaining.TotalSeconds:F0}s remaining)");
+                    await Task.Delay(retryDelay, cancellationToken);
+
+                    // Exponential backoff capped at maxRetryDelay
+                    retryDelay = TimeSpan.FromSeconds(Math.Min(retryDelay.TotalSeconds * 1.5, maxRetryDelay.TotalSeconds));
+                }
+            }
+
+            if (pendingAgents.Count > 0)
+            {
+                foreach (var agent in pendingAgents)
+                {
+                    Log.WriteError($"Agent '{agent.ServiceName}' at {agent.EndpointUri} failed to become ready within timeout.");
+                }
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public async Task<int> CleanupOrphanedResourcesAsync(
+            TimeSpan maxAge,
+            CancellationToken cancellationToken = default)
+        {
+            var subscription = await GetSubscriptionAsync(cancellationToken);
+            var cutoff = DateTime.UtcNow - maxAge;
+            var cleaned = 0;
+
+            await foreach (var rg in subscription.GetResourceGroups().GetAllAsync(cancellationToken: cancellationToken))
+            {
+                if (rg.Data.Tags.TryGetValue(TagManagedBy, out var managedBy) && managedBy == "crank-controller")
+                {
+                    if (rg.Data.Tags.TryGetValue(TagCreatedAt, out var createdAtStr)
+                        && DateTime.TryParse(createdAtStr, out var createdAt)
+                        && createdAt < cutoff)
+                    {
+                        Log.Write($"Cleaning up orphaned resource group '{rg.Data.Name}' (created {createdAt:u})...");
+                        await rg.DeleteAsync(WaitUntil.Started, cancellationToken: cancellationToken);
+                        cleaned++;
+                    }
+                }
+            }
+
+            return cleaned;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            // Teardown all tracked sessions
+            foreach (var sessionId in _sessionResourceGroups.Keys.ToList())
+            {
+                await TeardownAsync(sessionId);
+            }
+
+            _httpClient?.Dispose();
+        }
+
+        private async Task<SubscriptionResource> GetSubscriptionAsync(CancellationToken cancellationToken)
+        {
+            if (_subscription != null)
+            {
+                return _subscription;
+            }
+
+            return await _armClient.GetDefaultSubscriptionAsync(cancellationToken);
+        }
+
+        private static async Task<(VirtualNetworkResource vnet, NetworkSecurityGroupResource nsg)> CreateNetworkingAsync(
+            ResourceGroupResource resourceGroup,
+            string region,
+            IDictionary<string, ProvisioningConfig> agentConfigs,
+            CancellationToken cancellationToken)
+        {
+            var location = new AzureLocation(region);
+
+            // Collect all agent ports used
+            var agentPorts = agentConfigs.Values.Select(c => c.AgentPort).Distinct().ToList();
+
+            // Create NSG with rules for agent ports
+            var nsgData = new NetworkSecurityGroupData { Location = location };
+
+            int priority = 100;
+            foreach (var port in agentPorts)
+            {
+                nsgData.SecurityRules.Add(new SecurityRuleData
+                {
+                    Name = $"allow-crank-agent-{port}",
+                    Priority = priority++,
+                    Direction = SecurityRuleDirection.Inbound,
+                    Access = SecurityRuleAccess.Allow,
+                    Protocol = SecurityRuleProtocol.Tcp,
+                    SourceAddressPrefix = "*",
+                    SourcePortRange = "*",
+                    DestinationAddressPrefix = "*",
+                    DestinationPortRange = port.ToString()
+                });
+            }
+
+            // Allow SSH for debugging
+            nsgData.SecurityRules.Add(new SecurityRuleData
+            {
+                Name = "allow-ssh",
+                Priority = priority++,
+                Direction = SecurityRuleDirection.Inbound,
+                Access = SecurityRuleAccess.Allow,
+                Protocol = SecurityRuleProtocol.Tcp,
+                SourceAddressPrefix = "*",
+                SourcePortRange = "*",
+                DestinationAddressPrefix = "*",
+                DestinationPortRange = "22"
+            });
+
+            var nsgCollection = resourceGroup.GetNetworkSecurityGroups();
+            var nsgOperation = await nsgCollection.CreateOrUpdateAsync(
+                WaitUntil.Completed, "nsg-crank-agents", nsgData, cancellationToken);
+            var nsg = nsgOperation.Value;
+
+            // Create VNet + Subnet
+            var vnetData = new VirtualNetworkData
+            {
+                Location = location,
+                AddressPrefixes = { "10.0.0.0/16" },
+                Subnets =
+                {
+                    new SubnetData
+                    {
+                        Name = "subnet-agents",
+                        AddressPrefix = "10.0.1.0/24",
+                        NetworkSecurityGroup = new NetworkSecurityGroupData { Id = nsg.Id }
+                    }
+                }
+            };
+
+            var vnetCollection = resourceGroup.GetVirtualNetworks();
+            var vnetOperation = await vnetCollection.CreateOrUpdateAsync(
+                WaitUntil.Completed, "vnet-crank", vnetData, cancellationToken);
+            var vnet = vnetOperation.Value;
+
+            return (vnet, nsg);
+        }
+
+        private static async Task<List<ProvisionedAgent>> ProvisionServiceVmsAsync(
+            ResourceGroupResource resourceGroup,
+            VirtualNetworkResource vnet,
+            NetworkSecurityGroupResource nsg,
+            string serviceName,
+            ProvisioningConfig config,
+            string region,
+            string sessionId,
+            CancellationToken cancellationToken)
+        {
+            var agents = new List<ProvisionedAgent>();
+            var location = new AzureLocation(region);
+            var subnetId = vnet.Data.Subnets.First().Id;
+
+            var vmTasks = new List<Task<ProvisionedAgent>>();
+
+            for (int i = 0; i < config.Count; i++)
+            {
+                var index = i;
+                vmTasks.Add(ProvisionSingleVmAsync(
+                    resourceGroup, subnetId, serviceName, config, location, sessionId, index, cancellationToken));
+            }
+
+            var results = await Task.WhenAll(vmTasks);
+            agents.AddRange(results);
+
+            return agents;
+        }
+
+        private static async Task<ProvisionedAgent> ProvisionSingleVmAsync(
+            ResourceGroupResource resourceGroup,
+            ResourceIdentifier subnetId,
+            string serviceName,
+            ProvisioningConfig config,
+            AzureLocation location,
+            string sessionId,
+            int index,
+            CancellationToken cancellationToken)
+        {
+            var vmName = $"vm-{serviceName}-{index}";
+            var nicName = $"nic-{serviceName}-{index}";
+            var pipName = $"pip-{serviceName}-{index}";
+
+            Log.Write($"Provisioning VM '{vmName}' ({config.VmSize}, {config.Os})...");
+
+            // Create Public IP
+            var pipData = new PublicIPAddressData
+            {
+                Location = location,
+                PublicIPAllocationMethod = NetworkIPAllocationMethod.Static,
+                Sku = new PublicIPAddressSku { Name = PublicIPAddressSkuName.Standard }
+            };
+
+            var pipCollection = resourceGroup.GetPublicIPAddresses();
+            var pipOperation = await pipCollection.CreateOrUpdateAsync(
+                WaitUntil.Completed, pipName, pipData, cancellationToken);
+            var pip = pipOperation.Value;
+
+            // Create NIC
+            var nicData = new NetworkInterfaceData
+            {
+                Location = location,
+                IPConfigurations =
+                {
+                    new NetworkInterfaceIPConfigurationData
+                    {
+                        Name = "ipconfig1",
+                        Subnet = new SubnetData { Id = subnetId },
+                        PublicIPAddress = new PublicIPAddressData { Id = pip.Id }
+                    }
+                }
+            };
+
+            var nicCollection = resourceGroup.GetNetworkInterfaces();
+            var nicOperation = await nicCollection.CreateOrUpdateAsync(
+                WaitUntil.Completed, nicName, nicData, cancellationToken);
+            var nic = nicOperation.Value;
+
+            // Determine image reference
+            var imageReference = GetImageReference(config);
+
+            // Build cloud-init script
+            var cloudInit = GenerateCloudInitScript(config);
+            var cloudInitBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(cloudInit));
+
+            // Create VM
+            var vmData = new VirtualMachineData(location)
+            {
+                HardwareProfile = new VirtualMachineHardwareProfile
+                {
+                    VmSize = new VirtualMachineSizeType(config.VmSize)
+                },
+                OSProfile = new VirtualMachineOSProfile
+                {
+                    ComputerName = vmName.Length > 15 ? vmName.Substring(0, 15) : vmName,
+                    AdminUsername = "crankadmin",
+                    CustomData = cloudInitBase64,
+                    LinuxConfiguration = config.Os.ToLowerInvariant() == "linux"
+                        ? new LinuxConfiguration
+                        {
+                            DisablePasswordAuthentication = true,
+                            SshPublicKeys =
+                            {
+                                // Use a generated key pair — in production this would come from config
+                                new SshPublicKeyConfiguration
+                                {
+                                    Path = "/home/crankadmin/.ssh/authorized_keys",
+                                    KeyData = GenerateTemporarySshKey()
+                                }
+                            }
+                        }
+                        : null,
+                    WindowsConfiguration = config.Os.ToLowerInvariant() == "windows"
+                        ? new WindowsConfiguration
+                        {
+                            ProvisionVmAgent = true
+                        }
+                        : null
+                },
+                StorageProfile = new VirtualMachineStorageProfile
+                {
+                    ImageReference = imageReference,
+                    OSDisk = new VirtualMachineOSDisk(DiskCreateOptionType.FromImage)
+                    {
+                        Name = $"osdisk-{serviceName}-{index}",
+                        ManagedDisk = new VirtualMachineManagedDisk
+                        {
+                            StorageAccountType = StorageAccountType.PremiumLrs
+                        },
+                        DiskSizeGB = 128,
+                        DeleteOption = DiskDeleteOptionType.Delete
+                    }
+                },
+                NetworkProfile = new VirtualMachineNetworkProfile
+                {
+                    NetworkInterfaces =
+                    {
+                        new VirtualMachineNetworkInterfaceReference
+                        {
+                            Id = nic.Id,
+                            Primary = true
+                        }
+                    }
+                }
+            };
+
+            // Apply session tags
+            vmData.Tags.Add(TagSessionId, sessionId);
+            vmData.Tags.Add(TagCreatedAt, DateTime.UtcNow.ToString("o"));
+            vmData.Tags.Add(TagManagedBy, "crank-controller");
+            vmData.Tags.Add("crank-service", serviceName);
+
+            // Apply custom tags
+            foreach (var tag in config.Tags)
+            {
+                vmData.Tags[tag.Key] = tag.Value;
+            }
+
+            // Configure spot instance if requested
+            if (config.SpotInstance)
+            {
+                vmData.Priority = VirtualMachinePriorityType.Spot;
+                vmData.EvictionPolicy = VirtualMachineEvictionPolicyType.Deallocate;
+                vmData.BillingMaxPrice = -1; // Pay up to on-demand price
+            }
+
+            var vmCollection = resourceGroup.GetVirtualMachines();
+            var vmOperation = await vmCollection.CreateOrUpdateAsync(
+                WaitUntil.Completed, vmName, vmData, cancellationToken);
+            var vm = vmOperation.Value;
+
+            // Get the public IP address
+            var updatedPip = await pipCollection.GetAsync(pipName, cancellationToken: cancellationToken);
+            var publicIp = updatedPip.Value.Data.IPAddress;
+
+            Log.Write($"VM '{vmName}' provisioned with IP {publicIp}.");
+
+            return new ProvisionedAgent
+            {
+                EndpointUri = new Uri($"http://{publicIp}:{config.AgentPort}"),
+                IpAddress = publicIp,
+                Hostname = vmName,
+                ResourceGroupName = resourceGroup.Data.Name,
+                VmName = vmName,
+                ServiceName = serviceName
+            };
+        }
+
+        private static ImageReference GetImageReference(ProvisioningConfig config)
+        {
+            if (!string.IsNullOrEmpty(config.CustomImageId))
+            {
+                return new ImageReference { Id = new ResourceIdentifier(config.CustomImageId) };
+            }
+
+            return config.Image?.ToLowerInvariant() switch
+            {
+                "ubuntu-22.04" => new ImageReference
+                {
+                    Publisher = "Canonical",
+                    Offer = "0001-com-ubuntu-server-jammy",
+                    Sku = "22_04-lts-gen2",
+                    Version = "latest"
+                },
+                "ubuntu-24.04" => new ImageReference
+                {
+                    Publisher = "Canonical",
+                    Offer = "ubuntu-24_04-lts",
+                    Sku = "server",
+                    Version = "latest"
+                },
+                "windows-2022" => new ImageReference
+                {
+                    Publisher = "MicrosoftWindowsServer",
+                    Offer = "WindowsServer",
+                    Sku = "2022-datacenter-g2",
+                    Version = "latest"
+                },
+                "windows-2025" => new ImageReference
+                {
+                    Publisher = "MicrosoftWindowsServer",
+                    Offer = "WindowsServer",
+                    Sku = "2025-datacenter-g2",
+                    Version = "latest"
+                },
+                _ => new ImageReference
+                {
+                    Publisher = "Canonical",
+                    Offer = "0001-com-ubuntu-server-jammy",
+                    Sku = "22_04-lts-gen2",
+                    Version = "latest"
+                }
+            };
+        }
+
+        internal static string GenerateCloudInitScript(ProvisioningConfig config)
+        {
+            var sb = new StringBuilder();
+
+            if (config.Os.ToLowerInvariant() == "linux")
+            {
+                sb.AppendLine("#!/bin/bash");
+                sb.AppendLine("set -euo pipefail");
+                sb.AppendLine();
+                sb.AppendLine("# Log all output for diagnostics");
+                sb.AppendLine("exec > /var/log/crank-agent-setup.log 2>&1");
+                sb.AppendLine();
+
+                if (!string.IsNullOrEmpty(config.AgentImage))
+                {
+                    // Docker-based agent deployment
+                    sb.AppendLine("# Install Docker");
+                    sb.AppendLine("curl -fsSL https://get.docker.com | sh");
+                    sb.AppendLine("systemctl enable docker && systemctl start docker");
+                    sb.AppendLine();
+                    sb.AppendLine("# Pull and run the crank agent container");
+                    sb.AppendLine($"docker pull {config.AgentImage}");
+                    sb.AppendLine($"docker run -d --restart=always --name crank-agent \\");
+                    sb.AppendLine($"  --network host \\");
+                    sb.AppendLine($"  -v /var/run/docker.sock:/var/run/docker.sock \\");
+                    sb.AppendLine($"  {config.AgentImage} --url http://*:{config.AgentPort}");
+                }
+                else
+                {
+                    // Direct dotnet tool install
+                    sb.AppendLine("# Install prerequisites");
+                    sb.AppendLine("apt-get update && apt-get install -y --no-install-recommends \\");
+                    sb.AppendLine("    git procps curl wget libgdiplus gnupg2 software-properties-common");
+                    sb.AppendLine();
+                    sb.AppendLine("# Install .NET SDK");
+                    sb.AppendLine("wget -q https://dot.net/v1/dotnet-install.sh -O /tmp/dotnet-install.sh");
+                    sb.AppendLine("chmod +x /tmp/dotnet-install.sh");
+                    sb.AppendLine("/tmp/dotnet-install.sh --channel 8.0 --install-dir /usr/share/dotnet");
+                    sb.AppendLine("ln -sf /usr/share/dotnet/dotnet /usr/bin/dotnet");
+                    sb.AppendLine("export DOTNET_ROOT=/usr/share/dotnet");
+                    sb.AppendLine("export PATH=\"$PATH:/usr/share/dotnet:/root/.dotnet/tools\"");
+                    sb.AppendLine();
+                    sb.AppendLine("# Install crank-agent");
+                    sb.AppendLine("dotnet tool install -g Microsoft.Crank.Agent --version \"0.2.0-*\"");
+                    sb.AppendLine();
+                    sb.AppendLine("# Create a systemd service for the agent");
+                    sb.AppendLine("cat > /etc/systemd/system/crank-agent.service << 'EOF'");
+                    sb.AppendLine("[Unit]");
+                    sb.AppendLine("Description=Crank Benchmarking Agent");
+                    sb.AppendLine("After=network.target");
+                    sb.AppendLine();
+                    sb.AppendLine("[Service]");
+                    sb.AppendLine("Type=simple");
+                    sb.AppendLine($"ExecStart=/root/.dotnet/tools/crank-agent --url http://*:{config.AgentPort}");
+                    sb.AppendLine("Restart=always");
+                    sb.AppendLine("RestartSec=5");
+                    sb.AppendLine("Environment=DOTNET_ROOT=/usr/share/dotnet");
+                    sb.AppendLine("Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/share/dotnet:/root/.dotnet/tools");
+                    sb.AppendLine();
+                    sb.AppendLine("[Install]");
+                    sb.AppendLine("WantedBy=multi-user.target");
+                    sb.AppendLine("EOF");
+                    sb.AppendLine();
+                    sb.AppendLine("systemctl daemon-reload");
+                    sb.AppendLine("systemctl enable crank-agent");
+                    sb.AppendLine("systemctl start crank-agent");
+                }
+            }
+            else
+            {
+                // Windows cloud-init (CustomScriptExtension would be used instead typically)
+                sb.AppendLine("# PowerShell setup script for Windows");
+                sb.AppendLine("$ErrorActionPreference = 'Stop'");
+                sb.AppendLine();
+                sb.AppendLine("# Install .NET SDK");
+                sb.AppendLine("Invoke-WebRequest -Uri https://dot.net/v1/dotnet-install.ps1 -OutFile dotnet-install.ps1");
+                sb.AppendLine(".\\dotnet-install.ps1 -Channel 8.0");
+                sb.AppendLine("$env:PATH = \"$env:USERPROFILE\\.dotnet;$env:USERPROFILE\\.dotnet\\tools;$env:PATH\"");
+                sb.AppendLine();
+                sb.AppendLine("# Install crank-agent");
+                sb.AppendLine("dotnet tool install -g Microsoft.Crank.Agent --version \"0.2.0-*\"");
+                sb.AppendLine();
+                sb.AppendLine("# Start the agent");
+                sb.AppendLine($"Start-Process -NoNewWindow -FilePath crank-agent -ArgumentList '--url http://*:{config.AgentPort}'");
+            }
+
+            return sb.ToString();
+        }
+
+        private static string GenerateTemporarySshKey()
+        {
+            // In a real implementation, this would generate or load an SSH key pair.
+            // For now, we return a placeholder that would need to be replaced with an actual key.
+            // The controller should accept an SSH key via CLI option or generate one per session.
+            return "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC-PLACEHOLDER crank-agent-temp-key";
+        }
+    }
+}

--- a/src/Microsoft.Crank.Controller/Provisioning/AzureProvisioner.cs
+++ b/src/Microsoft.Crank.Controller/Provisioning/AzureProvisioner.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Crank.Controller.Provisioning
         private const string TagCreatedAt = "crank-created-at";
         private const string TagAutoDeleteAfter = "crank-auto-delete-after";
         private const string TagManagedBy = "crank-managed-by";
+        private const string TagPoolName = "crank-pool";
 
         private static readonly TimeSpan DefaultAutoDeleteAfter = TimeSpan.FromHours(2);
 
@@ -65,12 +66,27 @@ namespace Microsoft.Crank.Controller.Provisioning
             IDictionary<string, ProvisioningConfig> agentConfigs,
             CancellationToken cancellationToken = default)
         {
+            return await ProvisionAsync(sessionId, agentConfigs, poolName: null, poolTtl: null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Provisions infrastructure with optional pool naming for reuse across runs.
+        /// </summary>
+        public async Task<IReadOnlyList<ProvisionedAgent>> ProvisionAsync(
+            string sessionId,
+            IDictionary<string, ProvisioningConfig> agentConfigs,
+            string poolName,
+            TimeSpan? poolTtl,
+            CancellationToken cancellationToken = default)
+        {
             var agents = new List<ProvisionedAgent>();
             var subscription = await GetSubscriptionAsync(cancellationToken);
 
-            // Group agents by resource group (use shared RG or per-session)
-            var resourceGroupName = agentConfigs.Values.FirstOrDefault()?.ResourceGroup
-                ?? $"{ResourceGroupPrefix}{sessionId}";
+            // When using a pool, name the resource group deterministically so it can be found later
+            var resourceGroupName = !string.IsNullOrEmpty(poolName)
+                ? $"{ResourceGroupPrefix}pool-{poolName}"
+                : agentConfigs.Values.FirstOrDefault()?.ResourceGroup
+                    ?? $"{ResourceGroupPrefix}{sessionId}";
 
             _sessionResourceGroups[sessionId] = resourceGroupName;
 
@@ -83,8 +99,16 @@ namespace Microsoft.Crank.Controller.Provisioning
             var rgData = new ResourceGroupData(new AzureLocation(region));
             rgData.Tags.Add(TagSessionId, sessionId);
             rgData.Tags.Add(TagCreatedAt, DateTime.UtcNow.ToString("o"));
-            rgData.Tags.Add(TagAutoDeleteAfter, DateTime.UtcNow.Add(DefaultAutoDeleteAfter).ToString("o"));
             rgData.Tags.Add(TagManagedBy, "crank-controller");
+
+            // Set auto-delete based on pool TTL or default
+            var autoDeleteAfter = poolTtl ?? DefaultAutoDeleteAfter;
+            rgData.Tags.Add(TagAutoDeleteAfter, DateTime.UtcNow.Add(autoDeleteAfter).ToString("o"));
+
+            if (!string.IsNullOrEmpty(poolName))
+            {
+                rgData.Tags.Add(TagPoolName, poolName);
+            }
 
             var rgCollection = subscription.GetResourceGroups();
             var rgOperation = await rgCollection.CreateOrUpdateAsync(
@@ -247,6 +271,177 @@ namespace Microsoft.Crank.Controller.Provisioning
             }
 
             return cleaned;
+        }
+
+        /// <inheritdoc/>
+        public async Task<IReadOnlyList<ProvisionedAgent>> FindExistingPoolAsync(
+            string poolName,
+            IDictionary<string, ProvisioningConfig> agentConfigs,
+            CancellationToken cancellationToken = default)
+        {
+            var subscription = await GetSubscriptionAsync(cancellationToken);
+            var expectedRgName = $"{ResourceGroupPrefix}pool-{poolName}";
+
+            Log.Write($"Searching for existing pool '{poolName}' (resource group '{expectedRgName}')...");
+
+            ResourceGroupResource resourceGroup;
+            try
+            {
+                var rgResponse = await subscription.GetResourceGroups()
+                    .GetAsync(expectedRgName, cancellationToken);
+                resourceGroup = rgResponse.Value;
+            }
+            catch (RequestFailedException ex) when (ex.Status == 404)
+            {
+                Log.Write($"No existing pool '{poolName}' found.");
+                return null;
+            }
+
+            // Verify it's a crank-managed pool
+            if (!resourceGroup.Data.Tags.TryGetValue(TagManagedBy, out var managedBy) || managedBy != "crank-controller")
+            {
+                Log.Write($"Resource group '{expectedRgName}' exists but is not crank-managed. Skipping.");
+                return null;
+            }
+
+            if (!resourceGroup.Data.Tags.TryGetValue(TagPoolName, out var taggedPool) || taggedPool != poolName)
+            {
+                Log.Write($"Resource group '{expectedRgName}' exists but has wrong pool tag. Skipping.");
+                return null;
+            }
+
+            // Check if it has expired
+            if (resourceGroup.Data.Tags.TryGetValue(TagAutoDeleteAfter, out var autoDeleteStr)
+                && DateTime.TryParse(autoDeleteStr, out var autoDeleteAt)
+                && DateTime.UtcNow > autoDeleteAt)
+            {
+                Log.Write($"Pool '{poolName}' has expired (auto-delete was {autoDeleteAt:u}). Will provision fresh.");
+                return null;
+            }
+
+            // Discover VMs and build ProvisionedAgent list from existing resources
+            var agents = new List<ProvisionedAgent>();
+
+            await foreach (var vm in resourceGroup.GetVirtualMachines().GetAllAsync(cancellationToken: cancellationToken))
+            {
+                // VM naming convention: vm-{serviceName}-{index}
+                var vmName = vm.Data.Name;
+                var parts = vmName.Split('-');
+                // Expect "vm-{serviceName}-{index}", serviceName may contain hyphens
+                string serviceName = null;
+                if (parts.Length >= 3 && parts[0] == "vm")
+                {
+                    // Rejoin everything between first and last dash segment
+                    serviceName = string.Join("-", parts.Skip(1).Take(parts.Length - 2));
+                }
+
+                if (serviceName == null || !agentConfigs.ContainsKey(serviceName))
+                {
+                    continue;
+                }
+
+                var config = agentConfigs[serviceName];
+
+                // Find the public IP of this VM through its NIC
+                string publicIp = null;
+                foreach (var nicRef in vm.Data.NetworkProfile.NetworkInterfaces)
+                {
+                    try
+                    {
+                        var nicResource = _armClient.GetNetworkInterfaceResource(nicRef.Id);
+                        var nic = await nicResource.GetAsync(cancellationToken: cancellationToken);
+                        foreach (var ipConfig in nic.Value.Data.IPConfigurations)
+                        {
+                            if (ipConfig.PublicIPAddress?.Id != null)
+                            {
+                                var pipResource = _armClient.GetPublicIPAddressResource(ipConfig.PublicIPAddress.Id);
+                                var pip = await pipResource.GetAsync(cancellationToken: cancellationToken);
+                                publicIp = pip.Value.Data.IPAddress;
+                                break;
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.WriteWarning($"Could not resolve IP for VM '{vmName}': {ex.Message}");
+                    }
+
+                    if (publicIp != null) break;
+                }
+
+                if (publicIp == null)
+                {
+                    Log.WriteWarning($"Could not find public IP for VM '{vmName}' in pool '{poolName}'. Skipping.");
+                    continue;
+                }
+
+                agents.Add(new ProvisionedAgent
+                {
+                    EndpointUri = new Uri($"http://{publicIp}:{config.AgentPort}"),
+                    IpAddress = publicIp,
+                    Hostname = vmName,
+                    ResourceGroupName = expectedRgName,
+                    VmName = vmName,
+                    ServiceName = serviceName
+                });
+            }
+
+            if (agents.Count == 0)
+            {
+                Log.Write($"Pool '{poolName}' resource group exists but has no matching VMs.");
+                return null;
+            }
+
+            // Verify we have the expected number of agents per service
+            foreach (var (serviceName, config) in agentConfigs)
+            {
+                var serviceAgents = agents.Count(a => a.ServiceName == serviceName);
+                if (serviceAgents < config.Count)
+                {
+                    Log.Write($"Pool '{poolName}' has {serviceAgents} agent(s) for service '{serviceName}', expected {config.Count}. Will provision fresh.");
+                    return null;
+                }
+            }
+
+            Log.Write($"Found existing pool '{poolName}' with {agents.Count} agent(s).");
+            return agents;
+        }
+
+        /// <inheritdoc/>
+        public async Task ExtendPoolTtlAsync(
+            string poolName,
+            TimeSpan ttl,
+            CancellationToken cancellationToken = default)
+        {
+            var subscription = await GetSubscriptionAsync(cancellationToken);
+            var expectedRgName = $"{ResourceGroupPrefix}pool-{poolName}";
+
+            try
+            {
+                var rgResponse = await subscription.GetResourceGroups()
+                    .GetAsync(expectedRgName, cancellationToken);
+                var resourceGroup = rgResponse.Value;
+
+                var newExpiry = DateTime.UtcNow.Add(ttl);
+
+                // Update tags by re-applying the resource group with updated tag values
+                var rgData = new ResourceGroupData(resourceGroup.Data.Location);
+                foreach (var tag in resourceGroup.Data.Tags)
+                {
+                    rgData.Tags.Add(tag.Key, tag.Value);
+                }
+                rgData.Tags[TagAutoDeleteAfter] = newExpiry.ToString("o");
+                rgData.Tags[TagSessionId] = $"pool-{poolName}-extended";
+
+                await subscription.GetResourceGroups()
+                    .CreateOrUpdateAsync(WaitUntil.Completed, expectedRgName, rgData, cancellationToken);
+
+                Log.Write($"Extended pool '{poolName}' TTL to {newExpiry:u}.");
+            }
+            catch (Exception ex)
+            {
+                Log.WriteWarning($"Failed to extend pool '{poolName}' TTL: {ex.Message}");
+            }
         }
 
         public async ValueTask DisposeAsync()

--- a/src/Microsoft.Crank.Controller/Provisioning/AzureProvisioner.cs
+++ b/src/Microsoft.Crank.Controller/Provisioning/AzureProvisioner.cs
@@ -606,45 +606,15 @@ namespace Microsoft.Crank.Controller.Provisioning
                     sb.AppendLine($"  -v /var/run/docker.sock:/var/run/docker.sock \\");
                     sb.AppendLine($"  {config.AgentImage} --url http://*:{config.AgentPort}");
                 }
+                else if (!string.IsNullOrEmpty(config.AgentSource))
+                {
+                    // Build agent from source
+                    GenerateLinuxBuildFromSourceScript(sb, config);
+                }
                 else
                 {
                     // Direct dotnet tool install
-                    sb.AppendLine("# Install prerequisites");
-                    sb.AppendLine("apt-get update && apt-get install -y --no-install-recommends \\");
-                    sb.AppendLine("    git procps curl wget libgdiplus gnupg2 software-properties-common");
-                    sb.AppendLine();
-                    sb.AppendLine("# Install .NET SDK");
-                    sb.AppendLine("wget -q https://dot.net/v1/dotnet-install.sh -O /tmp/dotnet-install.sh");
-                    sb.AppendLine("chmod +x /tmp/dotnet-install.sh");
-                    sb.AppendLine("/tmp/dotnet-install.sh --channel 8.0 --install-dir /usr/share/dotnet");
-                    sb.AppendLine("ln -sf /usr/share/dotnet/dotnet /usr/bin/dotnet");
-                    sb.AppendLine("export DOTNET_ROOT=/usr/share/dotnet");
-                    sb.AppendLine("export PATH=\"$PATH:/usr/share/dotnet:/root/.dotnet/tools\"");
-                    sb.AppendLine();
-                    sb.AppendLine("# Install crank-agent");
-                    sb.AppendLine("dotnet tool install -g Microsoft.Crank.Agent --version \"0.2.0-*\"");
-                    sb.AppendLine();
-                    sb.AppendLine("# Create a systemd service for the agent");
-                    sb.AppendLine("cat > /etc/systemd/system/crank-agent.service << 'EOF'");
-                    sb.AppendLine("[Unit]");
-                    sb.AppendLine("Description=Crank Benchmarking Agent");
-                    sb.AppendLine("After=network.target");
-                    sb.AppendLine();
-                    sb.AppendLine("[Service]");
-                    sb.AppendLine("Type=simple");
-                    sb.AppendLine($"ExecStart=/root/.dotnet/tools/crank-agent --url http://*:{config.AgentPort}");
-                    sb.AppendLine("Restart=always");
-                    sb.AppendLine("RestartSec=5");
-                    sb.AppendLine("Environment=DOTNET_ROOT=/usr/share/dotnet");
-                    sb.AppendLine("Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/share/dotnet:/root/.dotnet/tools");
-                    sb.AppendLine();
-                    sb.AppendLine("[Install]");
-                    sb.AppendLine("WantedBy=multi-user.target");
-                    sb.AppendLine("EOF");
-                    sb.AppendLine();
-                    sb.AppendLine("systemctl daemon-reload");
-                    sb.AppendLine("systemctl enable crank-agent");
-                    sb.AppendLine("systemctl start crank-agent");
+                    GenerateLinuxDotnetToolInstallScript(sb, config);
                 }
             }
             else
@@ -658,14 +628,115 @@ namespace Microsoft.Crank.Controller.Provisioning
                 sb.AppendLine(".\\dotnet-install.ps1 -Channel 8.0");
                 sb.AppendLine("$env:PATH = \"$env:USERPROFILE\\.dotnet;$env:USERPROFILE\\.dotnet\\tools;$env:PATH\"");
                 sb.AppendLine();
-                sb.AppendLine("# Install crank-agent");
-                sb.AppendLine("dotnet tool install -g Microsoft.Crank.Agent --version \"0.2.0-*\"");
-                sb.AppendLine();
-                sb.AppendLine("# Start the agent");
-                sb.AppendLine($"Start-Process -NoNewWindow -FilePath crank-agent -ArgumentList '--url http://*:{config.AgentPort}'");
+
+                if (!string.IsNullOrEmpty(config.AgentSource))
+                {
+                    // Build agent from source on Windows
+                    sb.AppendLine("# Clone and build crank-agent from source");
+                    sb.AppendLine($"git clone {config.AgentSource} C:\\crank-source");
+                    sb.AppendLine("Set-Location C:\\crank-source");
+                    sb.AppendLine($"git checkout {config.AgentSourceBranch}");
+                    sb.AppendLine($"dotnet publish {config.AgentSourceProject} -c Release -o C:\\crank-agent");
+                    sb.AppendLine();
+                    sb.AppendLine("# Start the agent");
+                    sb.AppendLine($"Start-Process -NoNewWindow -FilePath dotnet -ArgumentList 'C:\\crank-agent\\Microsoft.Crank.Agent.dll --url http://*:{config.AgentPort}'");
+                }
+                else
+                {
+                    sb.AppendLine("# Install crank-agent");
+                    sb.AppendLine("dotnet tool install -g Microsoft.Crank.Agent --version \"0.2.0-*\"");
+                    sb.AppendLine();
+                    sb.AppendLine("# Start the agent");
+                    sb.AppendLine($"Start-Process -NoNewWindow -FilePath crank-agent -ArgumentList '--url http://*:{config.AgentPort}'");
+                }
             }
 
             return sb.ToString();
+        }
+
+        private static void GenerateLinuxBuildFromSourceScript(StringBuilder sb, ProvisioningConfig config)
+        {
+            sb.AppendLine("# Install prerequisites");
+            sb.AppendLine("apt-get update && apt-get install -y --no-install-recommends \\");
+            sb.AppendLine("    git procps curl wget libgdiplus gnupg2 software-properties-common");
+            sb.AppendLine();
+            sb.AppendLine("# Install .NET SDK");
+            sb.AppendLine("wget -q https://dot.net/v1/dotnet-install.sh -O /tmp/dotnet-install.sh");
+            sb.AppendLine("chmod +x /tmp/dotnet-install.sh");
+            sb.AppendLine("/tmp/dotnet-install.sh --channel 8.0 --install-dir /usr/share/dotnet");
+            sb.AppendLine("ln -sf /usr/share/dotnet/dotnet /usr/bin/dotnet");
+            sb.AppendLine("export DOTNET_ROOT=/usr/share/dotnet");
+            sb.AppendLine("export PATH=\"$PATH:/usr/share/dotnet\"");
+            sb.AppendLine();
+            sb.AppendLine("# Clone and build crank-agent from source");
+            sb.AppendLine($"git clone {config.AgentSource} /opt/crank-source");
+            sb.AppendLine("cd /opt/crank-source");
+            sb.AppendLine($"git checkout {config.AgentSourceBranch}");
+            sb.AppendLine("echo \"Building crank-agent from source at commit $(git rev-parse HEAD)...\"");
+            sb.AppendLine($"dotnet publish {config.AgentSourceProject} -c Release -o /opt/crank-agent");
+            sb.AppendLine();
+            sb.AppendLine("# Create a systemd service for the agent");
+            sb.AppendLine("cat > /etc/systemd/system/crank-agent.service << 'EOF'");
+            sb.AppendLine("[Unit]");
+            sb.AppendLine("Description=Crank Benchmarking Agent (built from source)");
+            sb.AppendLine("After=network.target");
+            sb.AppendLine();
+            sb.AppendLine("[Service]");
+            sb.AppendLine("Type=simple");
+            sb.AppendLine($"ExecStart=/usr/share/dotnet/dotnet /opt/crank-agent/Microsoft.Crank.Agent.dll --url http://*:{config.AgentPort}");
+            sb.AppendLine("Restart=always");
+            sb.AppendLine("RestartSec=5");
+            sb.AppendLine("WorkingDirectory=/opt/crank-agent");
+            sb.AppendLine("Environment=DOTNET_ROOT=/usr/share/dotnet");
+            sb.AppendLine("Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/share/dotnet");
+            sb.AppendLine();
+            sb.AppendLine("[Install]");
+            sb.AppendLine("WantedBy=multi-user.target");
+            sb.AppendLine("EOF");
+            sb.AppendLine();
+            sb.AppendLine("systemctl daemon-reload");
+            sb.AppendLine("systemctl enable crank-agent");
+            sb.AppendLine("systemctl start crank-agent");
+        }
+
+        private static void GenerateLinuxDotnetToolInstallScript(StringBuilder sb, ProvisioningConfig config)
+        {
+            sb.AppendLine("# Install prerequisites");
+            sb.AppendLine("apt-get update && apt-get install -y --no-install-recommends \\");
+            sb.AppendLine("    git procps curl wget libgdiplus gnupg2 software-properties-common");
+            sb.AppendLine();
+            sb.AppendLine("# Install .NET SDK");
+            sb.AppendLine("wget -q https://dot.net/v1/dotnet-install.sh -O /tmp/dotnet-install.sh");
+            sb.AppendLine("chmod +x /tmp/dotnet-install.sh");
+            sb.AppendLine("/tmp/dotnet-install.sh --channel 8.0 --install-dir /usr/share/dotnet");
+            sb.AppendLine("ln -sf /usr/share/dotnet/dotnet /usr/bin/dotnet");
+            sb.AppendLine("export DOTNET_ROOT=/usr/share/dotnet");
+            sb.AppendLine("export PATH=\"$PATH:/usr/share/dotnet:/root/.dotnet/tools\"");
+            sb.AppendLine();
+            sb.AppendLine("# Install crank-agent");
+            sb.AppendLine("dotnet tool install -g Microsoft.Crank.Agent --version \"0.2.0-*\"");
+            sb.AppendLine();
+            sb.AppendLine("# Create a systemd service for the agent");
+            sb.AppendLine("cat > /etc/systemd/system/crank-agent.service << 'EOF'");
+            sb.AppendLine("[Unit]");
+            sb.AppendLine("Description=Crank Benchmarking Agent");
+            sb.AppendLine("After=network.target");
+            sb.AppendLine();
+            sb.AppendLine("[Service]");
+            sb.AppendLine("Type=simple");
+            sb.AppendLine($"ExecStart=/root/.dotnet/tools/crank-agent --url http://*:{config.AgentPort}");
+            sb.AppendLine("Restart=always");
+            sb.AppendLine("RestartSec=5");
+            sb.AppendLine("Environment=DOTNET_ROOT=/usr/share/dotnet");
+            sb.AppendLine("Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/share/dotnet:/root/.dotnet/tools");
+            sb.AppendLine();
+            sb.AppendLine("[Install]");
+            sb.AppendLine("WantedBy=multi-user.target");
+            sb.AppendLine("EOF");
+            sb.AppendLine();
+            sb.AppendLine("systemctl daemon-reload");
+            sb.AppendLine("systemctl enable crank-agent");
+            sb.AppendLine("systemctl start crank-agent");
         }
 
         private static string GenerateTemporarySshKey()

--- a/src/Microsoft.Crank.Controller/Provisioning/AzureProvisioner.cs
+++ b/src/Microsoft.Crank.Controller/Provisioning/AzureProvisioner.cs
@@ -273,6 +273,32 @@ namespace Microsoft.Crank.Controller.Provisioning
             return cleaned;
         }
 
+        /// <summary>
+        /// Cleans up crank-managed resource groups that have passed their auto-delete-after time.
+        /// Called automatically at the start of each provisioned run to prevent cost accumulation.
+        /// </summary>
+        public async Task<int> CleanupExpiredResourcesAsync(CancellationToken cancellationToken = default)
+        {
+            var subscription = await GetSubscriptionAsync(cancellationToken);
+            var now = DateTime.UtcNow;
+            var cleaned = 0;
+
+            await foreach (var rg in subscription.GetResourceGroups().GetAllAsync(cancellationToken: cancellationToken))
+            {
+                if (rg.Data.Tags.TryGetValue(TagManagedBy, out var managedBy) && managedBy == "crank-controller"
+                    && rg.Data.Tags.TryGetValue(TagAutoDeleteAfter, out var autoDeleteStr)
+                    && DateTime.TryParse(autoDeleteStr, out var autoDeleteAt)
+                    && now > autoDeleteAt)
+                {
+                    Log.Write($"Auto-cleaning expired resource group '{rg.Data.Name}' (expired {autoDeleteAt:u})...");
+                    await rg.DeleteAsync(WaitUntil.Started, cancellationToken: cancellationToken);
+                    cleaned++;
+                }
+            }
+
+            return cleaned;
+        }
+
         /// <inheritdoc/>
         public async Task<IReadOnlyList<ProvisionedAgent>> FindExistingPoolAsync(
             string poolName,

--- a/src/Microsoft.Crank.Controller/Provisioning/IInfrastructureProvisioner.cs
+++ b/src/Microsoft.Crank.Controller/Provisioning/IInfrastructureProvisioner.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Crank.Controller.Provisioning
+{
+    /// <summary>
+    /// Interface for infrastructure provisioners that can dynamically create and destroy
+    /// crank agent environments in cloud providers.
+    /// </summary>
+    public interface IInfrastructureProvisioner : IAsyncDisposable
+    {
+        /// <summary>
+        /// Provisions infrastructure for a set of agent roles defined by their provisioning configs.
+        /// </summary>
+        /// <param name="sessionId">A unique session identifier used for resource naming and tagging.</param>
+        /// <param name="agentConfigs">
+        /// A dictionary mapping service names (e.g., "application", "load") to their provisioning configurations.
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of provisioned agent endpoints ready to accept jobs.</returns>
+        Task<IReadOnlyList<ProvisionedAgent>> ProvisionAsync(
+            string sessionId,
+            IDictionary<string, ProvisioningConfig> agentConfigs,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Tears down all infrastructure associated with a session.
+        /// This should be called in a finally block to ensure cleanup even on failure.
+        /// </summary>
+        /// <param name="sessionId">The session ID used during provisioning.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task TeardownAsync(string sessionId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Waits for all provisioned agents to become healthy and ready to accept jobs.
+        /// </summary>
+        /// <param name="agents">The provisioned agents to check.</param>
+        /// <param name="timeout">Maximum time to wait for agents to become ready.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>True if all agents are healthy; false if any agent failed to become ready.</returns>
+        Task<bool> WaitForAgentsReadyAsync(
+            IReadOnlyList<ProvisionedAgent> agents,
+            TimeSpan timeout,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Finds and cleans up orphaned resource groups from previous failed sessions.
+        /// </summary>
+        /// <param name="maxAge">Maximum age of resource groups to consider orphaned.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The number of orphaned resource groups cleaned up.</returns>
+        Task<int> CleanupOrphanedResourcesAsync(
+            TimeSpan maxAge,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Microsoft.Crank.Controller/Provisioning/IInfrastructureProvisioner.cs
+++ b/src/Microsoft.Crank.Controller/Provisioning/IInfrastructureProvisioner.cs
@@ -58,5 +58,29 @@ namespace Microsoft.Crank.Controller.Provisioning
         Task<int> CleanupOrphanedResourcesAsync(
             TimeSpan maxAge,
             CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Searches for an existing provisioned pool by name that has healthy agents.
+        /// Returns the provisioned agents if found, or null if no matching pool exists.
+        /// </summary>
+        /// <param name="poolName">The pool name to search for.</param>
+        /// <param name="agentConfigs">The expected agent configurations to validate against.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of provisioned agents from the existing pool, or null if not found.</returns>
+        Task<IReadOnlyList<ProvisionedAgent>> FindExistingPoolAsync(
+            string poolName,
+            IDictionary<string, ProvisioningConfig> agentConfigs,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Extends the time-to-live of a provisioned pool so it remains available for subsequent runs.
+        /// </summary>
+        /// <param name="poolName">The pool name to extend.</param>
+        /// <param name="ttl">How much additional time to keep the pool alive.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task ExtendPoolTtlAsync(
+            string poolName,
+            TimeSpan ttl,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.Crank.Controller/Provisioning/ProvisionedAgent.cs
+++ b/src/Microsoft.Crank.Controller/Provisioning/ProvisionedAgent.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Crank.Controller.Provisioning
+{
+    /// <summary>
+    /// Represents a dynamically provisioned agent endpoint.
+    /// </summary>
+    public class ProvisionedAgent
+    {
+        /// <summary>
+        /// The URI of the provisioned crank agent (e.g., http://1.2.3.4:5010).
+        /// </summary>
+        public Uri EndpointUri { get; set; }
+
+        /// <summary>
+        /// The public IP address of the provisioned VM.
+        /// </summary>
+        public string IpAddress { get; set; }
+
+        /// <summary>
+        /// The hostname of the provisioned VM.
+        /// </summary>
+        public string Hostname { get; set; }
+
+        /// <summary>
+        /// The Azure Resource Group containing this VM.
+        /// </summary>
+        public string ResourceGroupName { get; set; }
+
+        /// <summary>
+        /// The name of the VM in Azure.
+        /// </summary>
+        public string VmName { get; set; }
+
+        /// <summary>
+        /// The service name this agent is provisioned for (e.g., "application", "load").
+        /// </summary>
+        public string ServiceName { get; set; }
+    }
+}

--- a/src/Microsoft.Crank.Controller/Provisioning/ProvisioningConfig.cs
+++ b/src/Microsoft.Crank.Controller/Provisioning/ProvisioningConfig.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Crank.Controller.Provisioning
+{
+    /// <summary>
+    /// Configuration for dynamically provisioning infrastructure for a crank agent.
+    /// Specified in the profile YAML under the "provision" key for each agent.
+    /// </summary>
+    public class ProvisioningConfig
+    {
+        /// <summary>
+        /// The cloud provider to use (e.g., "azure"). Currently only "azure" is supported.
+        /// </summary>
+        public string Provider { get; set; } = "azure";
+
+        /// <summary>
+        /// The VM size/SKU (e.g., "Standard_D4s_v5").
+        /// </summary>
+        public string VmSize { get; set; } = "Standard_D4s_v5";
+
+        /// <summary>
+        /// The operating system for the VM (e.g., "linux" or "windows").
+        /// </summary>
+        public string Os { get; set; } = "linux";
+
+        /// <summary>
+        /// The Azure region to deploy to (e.g., "eastus2").
+        /// </summary>
+        public string Region { get; set; } = "eastus2";
+
+        /// <summary>
+        /// The OS image to use. For Azure, this maps to a VM image URN.
+        /// Examples: "ubuntu-22.04", "ubuntu-24.04", "windows-2022"
+        /// </summary>
+        public string Image { get; set; } = "ubuntu-22.04";
+
+        /// <summary>
+        /// A custom VM image resource ID to use instead of a marketplace image.
+        /// When set, this takes precedence over <see cref="Image"/>.
+        /// </summary>
+        public string CustomImageId { get; set; }
+
+        /// <summary>
+        /// Number of VM instances to provision for this agent role.
+        /// </summary>
+        public int Count { get; set; } = 1;
+
+        /// <summary>
+        /// The port the crank agent will listen on.
+        /// </summary>
+        public int AgentPort { get; set; } = 5010;
+
+        /// <summary>
+        /// Optional Docker image containing the crank agent.
+        /// When set, the VM will run the agent via Docker instead of dotnet tool install.
+        /// </summary>
+        public string AgentImage { get; set; }
+
+        /// <summary>
+        /// The Azure subscription ID to use. If not set, uses the default subscription.
+        /// </summary>
+        public string SubscriptionId { get; set; }
+
+        /// <summary>
+        /// Optional Azure Resource Group name to use. If not set, a unique name is generated.
+        /// </summary>
+        public string ResourceGroup { get; set; }
+
+        /// <summary>
+        /// Whether to use Azure Spot/Low-priority VMs for cost savings.
+        /// </summary>
+        public bool SpotInstance { get; set; }
+
+        /// <summary>
+        /// Additional tags to apply to the Azure resources.
+        /// </summary>
+        public Dictionary<string, string> Tags { get; set; } = new();
+    }
+}

--- a/src/Microsoft.Crank.Controller/Provisioning/ProvisioningConfig.cs
+++ b/src/Microsoft.Crank.Controller/Provisioning/ProvisioningConfig.cs
@@ -61,6 +61,28 @@ namespace Microsoft.Crank.Controller.Provisioning
         public string AgentImage { get; set; }
 
         /// <summary>
+        /// Optional Git repository URL to clone and build the crank agent from source.
+        /// When set (and <see cref="AgentImage"/> is not set), the agent is built from source
+        /// instead of using dotnet tool install.
+        /// Example: "https://github.com/dotnet/crank.git"
+        /// </summary>
+        public string AgentSource { get; set; }
+
+        /// <summary>
+        /// The branch, tag, or commit SHA to checkout when building from source.
+        /// Only used when <see cref="AgentSource"/> is set.
+        /// Defaults to "main".
+        /// </summary>
+        public string AgentSourceBranch { get; set; } = "main";
+
+        /// <summary>
+        /// The relative path to the agent project file within the source repository.
+        /// Only used when <see cref="AgentSource"/> is set.
+        /// Defaults to "src/Microsoft.Crank.Agent/Microsoft.Crank.Agent.csproj".
+        /// </summary>
+        public string AgentSourceProject { get; set; } = "src/Microsoft.Crank.Agent/Microsoft.Crank.Agent.csproj";
+
+        /// <summary>
         /// The Azure subscription ID to use. If not set, uses the default subscription.
         /// </summary>
         public string SubscriptionId { get; set; }

--- a/src/Microsoft.Crank.Controller/Provisioning/ProvisioningConfigParser.cs
+++ b/src/Microsoft.Crank.Controller/Provisioning/ProvisioningConfigParser.cs
@@ -1,0 +1,126 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Crank.Controller.Provisioning
+{
+    /// <summary>
+    /// Parses provisioning configuration from profile YAML/JSON.
+    /// Detects whether a profile's agents use static endpoints or dynamic provisioning.
+    /// </summary>
+    public static class ProvisioningConfigParser
+    {
+        /// <summary>
+        /// Extracts provisioning configurations from a merged profile JObject.
+        /// Returns a dictionary of service name → ProvisioningConfig for services that
+        /// have a "provision" block instead of (or in addition to) static "endpoints".
+        /// </summary>
+        /// <param name="profile">The merged profile JObject.</param>
+        /// <param name="scenarioServices">The service names in the current scenario.</param>
+        /// <returns>
+        /// Dictionary of service name → ProvisioningConfig. Empty if no provisioning is needed.
+        /// </returns>
+        public static Dictionary<string, ProvisioningConfig> ExtractProvisioningConfigs(
+            JObject profile,
+            IEnumerable<string> scenarioServices)
+        {
+            var result = new Dictionary<string, ProvisioningConfig>();
+
+            var agents = (profile["agents"] ?? profile["jobs"]) as JObject;
+            if (agents == null)
+            {
+                return result;
+            }
+
+            foreach (var serviceName in scenarioServices)
+            {
+                var agentConfig = FindAgentConfig(agents, serviceName);
+                if (agentConfig == null)
+                {
+                    continue;
+                }
+
+                var provision = agentConfig["provision"] as JObject;
+                if (provision == null)
+                {
+                    continue;
+                }
+
+                var config = new ProvisioningConfig
+                {
+                    Provider = provision["provider"]?.Value<string>() ?? "azure",
+                    VmSize = provision["vmSize"]?.Value<string>() ?? "Standard_D4s_v5",
+                    Os = provision["os"]?.Value<string>() ?? "linux",
+                    Region = provision["region"]?.Value<string>() ?? "eastus2",
+                    Image = provision["image"]?.Value<string>() ?? "ubuntu-22.04",
+                    CustomImageId = provision["customImageId"]?.Value<string>(),
+                    Count = provision["count"]?.Value<int>() ?? 1,
+                    AgentPort = provision["agentPort"]?.Value<int>() ?? 5010,
+                    AgentImage = provision["agentImage"]?.Value<string>(),
+                    SubscriptionId = provision["subscriptionId"]?.Value<string>(),
+                    ResourceGroup = provision["resourceGroup"]?.Value<string>(),
+                    SpotInstance = provision["spotInstance"]?.Value<bool>() ?? false
+                };
+
+                // Parse additional tags
+                var tags = provision["tags"] as JObject;
+                if (tags != null)
+                {
+                    foreach (var tagProperty in tags.Properties())
+                    {
+                        config.Tags[tagProperty.Name] = tagProperty.Value.Value<string>();
+                    }
+                }
+
+                result[serviceName] = config;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Checks whether a merged profile contains any provisioning configurations.
+        /// </summary>
+        public static bool HasProvisioningConfigs(JObject profile, IEnumerable<string> scenarioServices)
+        {
+            var agents = (profile["agents"] ?? profile["jobs"]) as JObject;
+            if (agents == null)
+            {
+                return false;
+            }
+
+            return scenarioServices.Any(serviceName =>
+            {
+                var agentConfig = FindAgentConfig(agents, serviceName);
+                return agentConfig?["provision"] != null;
+            });
+        }
+
+        private static JObject FindAgentConfig(JObject agents, string serviceName)
+        {
+            // Direct name match
+            if (agents[serviceName] is JObject direct)
+            {
+                return direct;
+            }
+
+            // Check aliases
+            foreach (var prop in agents.Properties())
+            {
+                if (prop.Value is JObject v
+                    && v.TryGetValue("aliases", out var aliases)
+                    && aliases is JArray aliasesArray
+                    && aliasesArray.Values<string>().Contains(serviceName))
+                {
+                    return v;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.Crank.Controller/Provisioning/ProvisioningConfigParser.cs
+++ b/src/Microsoft.Crank.Controller/Provisioning/ProvisioningConfigParser.cs
@@ -61,6 +61,9 @@ namespace Microsoft.Crank.Controller.Provisioning
                     Count = provision["count"]?.Value<int>() ?? 1,
                     AgentPort = provision["agentPort"]?.Value<int>() ?? 5010,
                     AgentImage = provision["agentImage"]?.Value<string>(),
+                    AgentSource = provision["agentSource"]?.Value<string>(),
+                    AgentSourceBranch = provision["agentSourceBranch"]?.Value<string>() ?? "main",
+                    AgentSourceProject = provision["agentSourceProject"]?.Value<string>() ?? "src/Microsoft.Crank.Agent/Microsoft.Crank.Agent.csproj",
                     SubscriptionId = provision["subscriptionId"]?.Value<string>(),
                     ResourceGroup = provision["resourceGroup"]?.Value<string>(),
                     SpotInstance = provision["spotInstance"]?.Value<bool>() ?? false

--- a/src/Microsoft.Crank.Controller/benchmarks.schema.json
+++ b/src/Microsoft.Crank.Controller/benchmarks.schema.json
@@ -192,6 +192,98 @@
       "required": [],
       "additionalProperties": { "$ref": "#/definitions/job" }
 
+    },
+    "provision": {
+      "type": "object",
+      "title": "Dynamic infrastructure provisioning configuration",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "title": "The cloud provider to use for provisioning",
+          "default": "azure",
+          "enum": ["azure"]
+        },
+        "vmSize": {
+          "type": "string",
+          "title": "The VM size/SKU to provision",
+          "default": "Standard_D4s_v5",
+          "examples": ["Standard_D2s_v5", "Standard_D4s_v5", "Standard_D8s_v5", "Standard_D16s_v5"]
+        },
+        "os": {
+          "type": "string",
+          "title": "The operating system for the VM",
+          "default": "linux",
+          "enum": ["linux", "windows"]
+        },
+        "region": {
+          "type": "string",
+          "title": "The Azure region to deploy to",
+          "default": "eastus2",
+          "examples": ["eastus2", "westus2", "centralus", "westeurope"]
+        },
+        "image": {
+          "type": "string",
+          "title": "The OS image to use",
+          "default": "ubuntu-22.04",
+          "examples": ["ubuntu-22.04", "ubuntu-24.04", "windows-2022", "windows-2025"]
+        },
+        "customImageId": {
+          "type": "string",
+          "title": "A custom VM image resource ID (overrides image)"
+        },
+        "count": {
+          "type": "integer",
+          "title": "Number of VM instances to provision",
+          "default": 1,
+          "minimum": 1
+        },
+        "agentPort": {
+          "type": "integer",
+          "title": "The port the crank agent will listen on",
+          "default": 5010
+        },
+        "agentImage": {
+          "type": "string",
+          "title": "Docker image containing the crank agent"
+        },
+        "subscriptionId": {
+          "type": "string",
+          "title": "Azure subscription ID to use"
+        },
+        "resourceGroup": {
+          "type": "string",
+          "title": "Azure Resource Group name (auto-generated if not set)"
+        },
+        "spotInstance": {
+          "type": "boolean",
+          "title": "Whether to use Azure Spot/Low-priority VMs",
+          "default": false
+        },
+        "tags": {
+          "type": "object",
+          "title": "Additional tags to apply to Azure resources",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    },
+    "profile_agent": {
+      "type": "object",
+      "title": "Agent configuration within a profile",
+      "properties": {
+        "endpoints": {
+          "type": "array",
+          "title": "Static agent endpoint URLs",
+          "items": { "type": "string" }
+        },
+        "provision": {
+          "$ref": "#/definitions/provision"
+        },
+        "aliases": {
+          "type": "array",
+          "title": "Alternative names for this agent",
+          "items": { "type": "string" }
+        }
+      }
     }
   },
   "properties": {
@@ -222,6 +314,29 @@
       ],
       "properties": {},
       "additionalProperties": { "$ref": "#/definitions/job_reference" }
+    },
+    "profiles": {
+      "type": "object",
+      "title": "Named profiles defining agent endpoints or provisioning configurations",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "variables": {
+            "type": "object",
+            "title": "Variables scoped to this profile"
+          },
+          "jobs": {
+            "type": "object",
+            "title": "Agent definitions (legacy name)",
+            "additionalProperties": { "$ref": "#/definitions/profile_agent" }
+          },
+          "agents": {
+            "type": "object",
+            "title": "Agent definitions",
+            "additionalProperties": { "$ref": "#/definitions/profile_agent" }
+          }
+        }
+      }
     }
   },
   "minProperties": 1,

--- a/src/Microsoft.Crank.Controller/benchmarks.schema.json
+++ b/src/Microsoft.Crank.Controller/benchmarks.schema.json
@@ -246,6 +246,22 @@
           "type": "string",
           "title": "Docker image containing the crank agent"
         },
+        "agentSource": {
+          "type": "string",
+          "title": "Git repository URL to clone and build the crank agent from source",
+          "examples": ["https://github.com/dotnet/crank.git"]
+        },
+        "agentSourceBranch": {
+          "type": "string",
+          "title": "Branch, tag, or commit SHA to checkout when building from source",
+          "default": "main",
+          "examples": ["main", "feature/my-branch", "abc123def"]
+        },
+        "agentSourceProject": {
+          "type": "string",
+          "title": "Relative path to the agent project file within the source repository",
+          "default": "src/Microsoft.Crank.Agent/Microsoft.Crank.Agent.csproj"
+        },
         "subscriptionId": {
           "type": "string",
           "title": "Azure subscription ID to use"


### PR DESCRIPTION
## Summary

Adds dynamic Azure VM provisioning for benchmark runs — provision, test, teardown in a single command.

## Key Features

- **`provision` block in profiles** — VM size, OS, region, agent deployment in YAML
- **Three agent deployment modes** — dotnet tool install, Docker, build from source
- **Provision pools** — reuse VMs across consecutive runs (`--provision-pool`)
- **Cost safety** — spot VMs, resource tagging, auto-cleanup, Ctrl+C teardown
- **Backward compatible** — existing static endpoint profiles unchanged

## New CLI Options

| Option | Description |
|--------|-------------|
| `--provision-timeout <min>` | Max wait for agents to become ready (default: 10) |
| `--no-teardown` | Skip teardown for debugging |
| `--provision-cleanup <hours>` | Clean up orphaned resources |
| `--provision-pool <name>` | Reuse VMs across runs |
| `--provision-pool-ttl <min>` | Pool idle lifetime (default: 30) |
| `--provision-pool-maxage <hours>` | Max pool age before refresh (default: 24) |

## Example

```yaml
profiles:
  azure:
    agents:
      application:
        provision:
          provider: azure
          vmSize: Standard_D4s_v5
          os: linux
          region: eastus2
      load:
        provision:
          provider: azure
          vmSize: Standard_D4s_v5
```

```bash
# Single run (provision + teardown)
crank --config bench.yml --scenario hello --profile azure

# Reuse VMs across multiple runs
crank --config bench.yml --scenario s1 --profile azure --provision-pool my-bench
crank --config bench.yml --scenario s2 --profile azure --provision-pool my-bench
```

See `docs/azure_provisioning.md` for full documentation.
