### PR TITLE
docker/agent: bump bundled docker CLI from 17.09.0-ce to 29.4.3

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -100,7 +100,7 @@ RUN cd /tmp \
     && make install || true
 
 # Install docker client
-ENV DOCKER_VERSION=17.09.0-ce
+ENV DOCKER_VERSION=29.4.3
 RUN cd /tmp \
     && curl "https://download.docker.com/linux/static/stable/${CPUNAME}/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
     && tar xvzf docker.tgz \

--- a/docker/agent/Dockerfile.AzureLinux3
+++ b/docker/agent/Dockerfile.AzureLinux3
@@ -68,7 +68,7 @@ RUN cd /tmp \
     && make install || true
 
 # Install docker client
-ENV DOCKER_VERSION=17.09.0-ce
+ENV DOCKER_VERSION=29.4.3
 RUN cd /tmp \
     && curl "https://download.docker.com/linux/static/stable/${CPUNAME}/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
     && tar xvzf docker.tgz \


### PR DESCRIPTION
## Problem

Crank's benchmarks-agent runs inside a Docker container with `/var/run/docker.sock` mounted in. The agent shells out to a bundled docker CLI pinned in this Dockerfile to **`17.09.0-ce` (Sep 2017, API 1.32)**. Once the host's Docker daemon was upgraded to 25+ (current host: 29.4.3), the daemon began rejecting that client outright:

```
Sending build context to Docker daemon  118.3kB
Error response from daemon: client version 1.32 is too old.
Minimum supported API version is 1.40, please upgrade your client to a newer version
```

This breaks **every** crank scenario that builds, pulls, or runs a docker image from inside the agent — anything driven by `source.dockerFile` / `application.docker*` etc. The wrapper surfaces only "Command docker build ... returned exit code 1" in the AzDO log; the real error above lives at the agent's `:5001/buildlog`, which is what made this hard to find. (Separate PR forthcoming for that surfacing improvement.)

## Concrete failure observed

`aspnet/benchmarks` pipeline `benchmarks-ci-azure` (def 1217), the **"Nginx: TLS Handshakes"** scenario (which uses `dockerLinuxNginxServer` → `src/BenchmarksApps/TLS/Nginx/Dockerfile` via `--build-arg ENABLE_FIPS_MODE=true`), failed on every scheduled main-branch run for ~2 weeks across every Linux Trends stage (azure-arm64, azure2-amd64, cobalt-cloud-lin, cobalt-cloud-lin-azl3-dual, idna-amd-lin, idna-intel-lin). Two other groups of scenarios (TechEmpower postgres container builds; container-matrix Middleware builds) failed with the identical wrapper signature. **None of the failing scenarios' Dockerfiles were actually broken** — the failure is a 100% match for the API-version rejection above, on any host where the crank-agent image was built from upstream main but the host daemon has been bumped.

## Fix

Two-line change. Bump `ENV DOCKER_VERSION` from `17.09.0-ce` to `29.4.3` in:
- `docker/agent/Dockerfile`
- `docker/agent/Dockerfile.AzureLinux3`

`29.4.3` matches the host daemon version on the affected agent VMs (eliminates client/daemon protocol drift) and is the most recent version with a corresponding static archive at upload time for both `aarch64` and `x86_64`. The Dockerfile's existing `${CPUNAME}/docker-${DOCKER_VERSION}.tgz` template handles both arches with no other changes.

## Verified on a real failing agent

`cobalt-server-lin` (arm64; backs the `9-Trends cobalt-cloud-lin` stage):

| | Before | After |
|---|---|---|
| `docker --version` inside agent container | `Docker version 17.09.0-ce, build afdb6d4` | `Docker version 29.4.3, build 055a478` |
| Daemon handshake | `client version 1.32 is too old. Minimum supported API version is 1.40` | API 1.54 negotiated cleanly |
| `docker build` of the failing nginx scenario, from inside the patched agent container | exit 1 (rejected) | `Successfully built f35443630770` |
| Build output wire-format | legacy (`Step N/M`, `---> Running in <id>`) | **same** legacy format |

The standalone CLI from the static archive ships without the buildx plugin, so it defaults to the legacy builder. `Microsoft.Crank.Agent` C# code is unchanged.