### PR TITLE
Install LTTng user-space packages in crank-agent images for perfcollect

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -40,7 +40,13 @@ RUN apt-get update \
         zlib1g-dev \
         libkrb5-dev \
         # .NET 9.0 requirement
-        libc6 
+        libc6 \
+        # perfcollect LTTng user-space tracepoints for .NET runtime events.
+        # Installed before the sid repos are added below so apt resolves these
+        # against the stable bookworm suite. perfcollect's own installer is a
+        # no-op on Ubuntu 22+ hosts.
+        lttng-tools \
+        liblttng-ust-dev 
 
 # Install HTTP/3 support
 RUN curl -LO https://packages.microsoft.com/keys/microsoft.asc && \

--- a/docker/agent/Dockerfile.AzureLinux3
+++ b/docker/agent/Dockerfile.AzureLinux3
@@ -37,7 +37,10 @@ RUN tdnf update -y \
         zlib-devel \
         krb5-devel \
         # .NET 9.0 requirement
-        glibc
+        glibc \
+        # perfcollect LTTng user-space tracepoints for .NET runtime events.
+        lttng-tools \
+        lttng-ust-devel
 
 # Install HTTP/3 support
 RUN tdnf install -y libmsquic


### PR DESCRIPTION
## What

Adds `lttng-tools` and the LTTng user-space development headers (`liblttng-ust-dev` on Debian, `lttng-ust-devel` on AzureLinux 3) to both crank-agent container images so perfcollect can capture the .NET runtime's DotNETRuntime tracepoints out of the box.

| File | Change |
|---|---|
| `docker/agent/Dockerfile` | Adds `lttng-tools` and `liblttng-ust-dev` to the existing bookworm apt block (placed *before* the sid sources are added later in the file so apt resolves against the stable bookworm suite) |
| `docker/agent/Dockerfile.AzureLinux3` | Adds `lttng-tools` and `lttng-ust-devel` to the existing tdnf install block |

11 lines added across the two files. No code changes.

## Why

When `crank-agent` runs on a recent host (this was reproduced on a cobalt-hosted Linux runner — **Ubuntu 24.04.3 aarch64**) and the controller requests a profile, perfcollect aborts with:

```
[INF] LTTng not installed.
[INF] Install LTTng to proceed.
```

The image *does* run `perfcollect install` during the docker build (see the `RUN /usr/bin/perfcollect install` step), but that installer:

- On Ubuntu >= 22, refuses to install LTTng without the `-force` flag and silently exits 0.
- On other distros, often misclassifies the container and skips the install.

Either way, the agent image ships without LTTng and any `--application.collect` / `--load.collect` run on that host fails before tracing starts. This is **not** something a user can work around with `--application.collectArguments` because the LTTng presence check runs before any of those flags are honored — the only fix is to make sure LTTng is present in the image.

Installing the user-space packages explicitly via the distro package manager sidesteps perfcollect's install heuristics entirely; perfcollect's own installer now no-ops with `LTTng already installed.`, which is what we want.

## Notes

- Only the **user-space** LTTng packages are installed. `lttng-modules-dkms` (the kernel module) is intentionally not added — perfcollect uses `perf_event` (not LTTng) for kernel-side sampling, and the lttng-modules dkms package has known build problems on recent Ubuntu kernels including the 24.04 6.8.x series.
- Traces produced with this change carry the same DotNETRuntime events (GC, JIT, loader, contention, threading, etc.) plus kernel CPU samples that crank users got on earlier Ubuntu releases. The `.trace.zip` opens in PerfView on Windows the same way.
- The bookworm change is placed before the sid sources are appended later in the Dockerfile so apt resolves the lttng stack cleanly against bookworm and doesn't get pulled into the t64 transition packages that come in with sid.
- A separate follow-up will look at the controller-side default `CollectArguments` string (which is currently PerfView-only syntax and produces benign `Unknown arg` INF noise when forwarded to perfcollect on Linux). That work is intentionally out of scope here so this fix can ship as a minimal unblock.

## Testing

- Rebuilt both images locally with Docker Desktop (linux/amd64) — both succeed and ship a working `lttng` binary (2.13.9 on bookworm, 2.13.11 on AzureLinux 3). The build-time `perfcollect install` step now prints `LTTng already installed.` in both.
- Validated end-to-end on the original failing setup: a cobalt-hosted Ubuntu 24.04.3 aarch64 host running `crank-agent` in the patched bookworm container — perfcollect now completes a collection and produces a usable `.trace.zip`.
