### PR TITLE
Agent: pass `-v` to `docker rm` to clean up anonymous volumes

### DIFF
--- a/src/Microsoft.Crank.Agent/Startup.cs
+++ b/src/Microsoft.Crank.Agent/Startup.cs
@@ -2330,8 +2330,11 @@ namespace Microsoft.Crank.Agent
             // Stop container in case it failed to stop earlier
             await ProcessUtil.RunAsync("docker", $"stop {containerName}", throwOnError: false);
 
-            // Delete container if the same name already exists
-            await ProcessUtil.RunAsync("docker", $"rm {imageName}", throwOnError: false);
+            // Delete container if the same name already exists.
+            // Use -v so any anonymous volumes attached to the leftover container
+            // (e.g. the data directory of mysql/postgres images that declare VOLUME)
+            // are removed too. Named volumes and bind mounts are preserved.
+            await ProcessUtil.RunAsync("docker", $"rm -v {containerName}", throwOnError: false);
 
             if (!String.IsNullOrWhiteSpace(job.CpuSet))
             {
@@ -2801,7 +2804,11 @@ namespace Microsoft.Crank.Agent
                 {
                     Log.Info($"Removing container {containerId}");
 
-                    await ProcessUtil.RunAsync("docker", $"rm --force {containerId}", throwOnError: false);
+                    // Use -v so any anonymous volumes attached to this container
+                    // (e.g. the data directory of mysql/postgres images that declare VOLUME)
+                    // are removed too. Named volumes and bind mounts are preserved, so
+                    // scenarios that opt into persistent storage via job.Arguments are unaffected.
+                    await ProcessUtil.RunAsync("docker", $"rm --force -v {containerId}", throwOnError: false);
 
                     if (!String.IsNullOrEmpty(job.BuildKey) && job.NoBuild)
                     {


### PR DESCRIPTION
## Problem

Crank agent machines (e.g. `asp-citrine-db`) have been filling up between daily `docker system prune -a --volumes -f` runs. Each prune reclaims ~29 GB, and analysis of a recent prune showed:

- ~208 anonymous Docker volumes deleted (~140 MB each on average)
- Only ~2 tagged images removed (`mysql:9.4`, `postgres:18-trixie`)
- Image-layer and build-cache churn are minor

The dominant disk consumer is **anonymous volumes left behind by database containers**.

## Root cause

The `mysql`, `postgres`, etc. images declare `VOLUME /var/lib/mysql` and `VOLUME /var/lib/postgresql/data` in their Dockerfiles. Every container started from one of these images without an explicit named/bind mount gets a **fresh anonymous volume** containing the initialized data dir.

The crank agent creates containers with `docker create`/`docker start` (it can't use `--rm` because `DockerCleanUpAsync` needs to inspect the stopped container's exit code), then later removes them with `docker rm`. Both `docker rm` invocations in `Startup.cs` were missing the `-v` flag:

- `DockerCleanUpAsync` (post-run, line ~2804): `docker rm --force {containerId}`
- Pre-start leftover cleanup (line ~2334): `docker rm {imageName}`

Without `-v`, anonymous volumes attached to the removed container are orphaned. Across daily benchmark runs this accounts for the ~29 GB/day accumulation observed in the prune output.

## Fix

Add `-v` to both `docker rm` calls.

`docker rm -v` only removes **anonymous** volumes attached to the container. It does **not** remove:

- Named volumes (`-v myvol:/data`)
- Bind mounts (`-v /host/path:/container/path`)

So scenarios that opt into persistent storage via `job.Arguments` are unaffected. Anonymous volumes aren''t addressable after container removal anyway, so cleaning them up is always the right behavior for crank''s per-job container lifecycle.

### Tightly-coupled secondary fix

The pre-start leftover cleanup at line 2334 was also using the wrong identifier - it called `docker rm {imageName}` instead of `{containerName}` (`containerName` = sanitized image name + `-{jobId}`, line 2328, which is the name actually passed to `docker create`). The leftover-container path therefore almost never matched anything. Fixed alongside the `-v` change since it''s on the same line.

## Why not `docker run --rm`?

`DockerCleanUpAsync` inspects the stopped container''s `State.Running` and `State.ExitCode` (lines 2778, 2784) to set the job''s success/failure state. `--rm` would delete the container the moment it exits, breaking that inspection. The agent''s create/start/inspect/rm flow is intentional - adding `-v` to the explicit `rm` is the minimal correct fix.

## Validation

- `dotnet build src/Microsoft.Crank.Agent/Microsoft.Crank.Agent.csproj` - clean, 0 warnings, 0 errors.
- Manual on a benchmark agent: run a DB-bearing scenario end-to-end. Before this change, `docker volume ls -q -f dangling=true | wc -l` grows by 1 per run; after this change, it stays flat.
- Quick pure-docker sanity check:
  ```bash
  # OLD behavior (leak)
  docker run -d --name pgtest -e POSTGRES_PASSWORD=crank postgres:18-trixie
  sleep 5 && docker stop pgtest && docker rm pgtest
  docker volume ls -q -f dangling=true | wc -l   # +1

  # NEW behavior (clean)
  docker run -d --name pgtest -e POSTGRES_PASSWORD=crank postgres:18-trixie
  sleep 5 && docker stop pgtest && docker rm -v pgtest
  docker volume ls -q -f dangling=true | wc -l   # flat
  ```

No new automated tests - `DockerCleanUpAsync` has no existing unit tests (verified with grep), and the behavior is a one-flag-on-an-exec-of-`docker` change.

## Risk

Effectively none for documented crank usage. Named volumes and bind mounts (the two ways scenarios opt into persistent storage) are not affected by `docker rm -v`.
