### PR TITLE
Reuse controller afterJob for result processing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@
 |**[Post-processing results](post_processing.md)** | Adding custom results and running scripts.
 |**[Running pre-commands](precommands.md)** | Running commands before the job is pushed to the agent.
 |**[Reporting custom measurements](measurements.md)** | How to push custom measurement from a job.
+|**[Deploying the Azure DevOps worker](../src/Microsoft.Crank.AzureDevOpsWorker/README.md)** | Configuring the queue worker and its optional external post-process hook.
 
 
 ## Reference documentation

--- a/src/Microsoft.Crank.AzureDevOpsWorker/AttemptExecution.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/AttemptExecution.cs
@@ -25,10 +25,21 @@ namespace Microsoft.Crank.AzureDevOpsWorker
         public static async Task<AttemptResult> ApplyPostProcessAsync(
             AttemptResult crankResult,
             PostProcessPayload postProcess,
-            Func<Task<PostProcessResult>> runPostProcessAsync)
+            Func<Task<PostProcessResult>> runPostProcessAsync,
+            Func<string, Task> writeLogAsync = null)
         {
             if (!crankResult.Succeeded || crankResult.Canceled || postProcess == null)
             {
+                return crankResult;
+            }
+
+            if (!postProcess.Enabled)
+            {
+                if (writeLogAsync != null)
+                {
+                    await writeLogAsync($"Post-process '{postProcess.GetSafeDisplayName()}' is disabled.");
+                }
+
                 return crankResult;
             }
 

--- a/src/Microsoft.Crank.AzureDevOpsWorker/AttemptExecution.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/AttemptExecution.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.Crank.AzureDevOpsWorker
+{
+    internal sealed class AttemptResult
+    {
+        public AttemptResult(bool succeeded, bool canceled = false)
+        {
+            Succeeded = succeeded;
+            Canceled = canceled;
+        }
+
+        public bool Succeeded { get; }
+
+        public bool Canceled { get; }
+    }
+
+    internal static class AttemptExecution
+    {
+        public static async Task<AttemptResult> ApplyPostProcessAsync(
+            AttemptResult crankResult,
+            PostProcessPayload postProcess,
+            Func<Task<PostProcessResult>> runPostProcessAsync)
+        {
+            if (!crankResult.Succeeded || crankResult.Canceled || postProcess == null)
+            {
+                return crankResult;
+            }
+
+            var postProcessResult = await runPostProcessAsync();
+            return new AttemptResult(postProcessResult.Succeeded, postProcessResult.Canceled);
+        }
+
+        public static async Task<AttemptResult> RunWithCleanupAsync(
+            string workingDirectory,
+            Func<Task<AttemptResult>> runAttemptAsync,
+            Action<string> cleanup)
+        {
+            try
+            {
+                return await runAttemptAsync();
+            }
+            finally
+            {
+                cleanup(workingDirectory);
+            }
+        }
+
+        public static async Task<AttemptResult> RunWithRetriesAsync(
+            int retryCount,
+            Func<int, Task<AttemptResult>> runAttemptAsync,
+            Action<int> onRetry)
+        {
+            AttemptResult result = null;
+            retryCount = Math.Max(0, retryCount);
+
+            for (var attempt = 0; attempt <= retryCount; attempt++)
+            {
+                if (attempt > 0)
+                {
+                    onRetry?.Invoke(attempt);
+                }
+
+                result = await runAttemptAsync(attempt);
+
+                if (result.Succeeded || result.Canceled)
+                {
+                    break;
+                }
+            }
+
+            return result ?? new AttemptResult(succeeded: false);
+        }
+    }
+}

--- a/src/Microsoft.Crank.AzureDevOpsWorker/DevopsMessage.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/DevopsMessage.cs
@@ -252,7 +252,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
             }
         }
 
-        public async Task<Records> GetRecordsAsync()
+        public async Task<Records> GetRecordsAsync(bool forceRefresh = false)
         {
             // NOTE: There is no API that allows to retrieve a single task details. Only the whole list.
             // So we cache the results to prevent rate limiting.
@@ -262,6 +262,11 @@ namespace Microsoft.Crank.AzureDevOpsWorker
             try
             {
                 // The application is single-threaded
+
+                if (forceRefresh)
+                {
+                    _memoryCache.Remove(getRecordsUrl);
+                }
 
                 var records = await _memoryCache.GetOrCreateAsync(getRecordsUrl, async entry =>
                 {

--- a/src/Microsoft.Crank.AzureDevOpsWorker/DevopsMessage.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/DevopsMessage.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
                 return false;
             }
         }
-        
+
         public async Task<bool> SendTaskCompletedEventAsync(ResultTypes resultType)
         {
             var taskCompletedEventUrl = $"{PlanUrl}/{ProjectId}/_apis/distributedtask/hubs/{HubName}/plans/{PlanId}/events?api-version=2.0-preview.1";
@@ -99,7 +99,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
                 jobId = JobId,
                 result = resultType.ToString().ToLowerInvariant()
             };
-            
+
             var requestBody = JsonSerializer.Serialize(body);
 
             try
@@ -119,7 +119,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
                 Console.WriteLine($"SendTaskCompletedEventAsync failed: {taskCompletedEventUrl}");
                 Console.WriteLine(e.ToString());
                 return false;
-            }        
+            }
         }
 
         public async Task<bool> SendTaskLogFeedsAsync(string message)
@@ -137,7 +137,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
             try
             {
                 var result = await PostDataAsync(taskLogFeedsUrl, requestBody);
-                
+
                 if (!result.IsSuccessStatusCode)
                 {
                     Console.WriteLine($"SendTaskLogFeedsAsync failed: {result.StatusCode} - {result.Content}");
@@ -195,7 +195,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
 
             var buffer = Encoding.UTF8.GetBytes(message);
             var byteContent = new ByteArrayContent(buffer);
-                       
+
             try
             {
                 var result = await PostDataAsync(appendLogContentUrl, byteContent);
@@ -258,7 +258,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
             // So we cache the results to prevent rate limiting.
 
             var getRecordsUrl = $"{PlanUrl}/{ProjectId}/_apis/distributedtask/hubs/{HubName}/plans/{PlanId}/timelines/{TimelineId}/records?api-version=4.1";
-            
+
             try
             {
                 // The application is single-threaded
@@ -272,8 +272,8 @@ namespace Microsoft.Crank.AzureDevOpsWorker
                 {
                     var result = await GetDataAsync(getRecordsUrl);
 
-                    result.EnsureSuccessStatusCode(); 
-                    
+                    result.EnsureSuccessStatusCode();
+
                     var content = await result.Content.ReadAsStringAsync();
 
                     var records = JsonSerializer.Deserialize<Records>(content, _serializationOptions);

--- a/src/Microsoft.Crank.AzureDevOpsWorker/Job.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/Job.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
         private ConcurrentQueue<string> _standardError = new ConcurrentQueue<string>();
 
         public StringBuilder OutputBuilder { get; private set; } = new StringBuilder();
-        
+
         public StringBuilder ErrorBuilder { get; private set; } = new StringBuilder();
 
         public Action<string> OnStandardOutput { get; set; }
@@ -34,7 +34,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
 
         public DateTime StartTimeUtc { get; private set; }
 
-        public Job (string applicationPath, string arguments, string workingDirectory = null)
+        public Job(string applicationPath, string arguments, string workingDirectory = null)
         {
             _process = new Process()
             {

--- a/src/Microsoft.Crank.AzureDevOpsWorker/JobPayload.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/JobPayload.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
             }
             catch (Exception e)
             {
-                throw new Exception($"Error while parsing message body ({data?.Length ?? 0} bytes).", e);
+                throw new JobPayloadParseException(data?.Length ?? 0, e.GetType());
             }
         }
     }

--- a/src/Microsoft.Crank.AzureDevOpsWorker/JobPayload.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/JobPayload.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
         public string Name { get; set; }
         public string[] Args { get; set; }
         public int Retries { get; set; } = 0;
+        public PostProcessPayload PostProcess { get; set; }
 
         // A JavaScript condition that must evaluate to true. "job" 
         public string Condition { get; set; }
@@ -64,7 +65,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
             }
             catch (Exception e)
             {
-                throw new Exception($"Error while parsing message body: {Convert.ToHexString(data)}", e);
+                throw new Exception($"Error while parsing message body ({data?.Length ?? 0} bytes).", e);
             }
         }
     }

--- a/src/Microsoft.Crank.AzureDevOpsWorker/JobPayload.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/JobPayload.cs
@@ -3,9 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
-using System.Collections.Generic;
 
 namespace Microsoft.Crank.AzureDevOpsWorker
 {
@@ -55,8 +55,8 @@ namespace Microsoft.Crank.AzureDevOpsWorker
                         throw new InvalidOperationException("Couldn't find beginning of JSON document.");
                     }
                 }
-                while (!char.IsWhiteSpace(str[index + 1]) && str[index + 1] != '\"');                
-                
+                while (!char.IsWhiteSpace(str[index + 1]) && str[index + 1] != '\"');
+
                 str = str.Substring(index);
                 str = str.Substring(0, str.LastIndexOf("}") + 1);
                 var result = JsonSerializer.Deserialize<JobPayload>(str, _serializationOptions);

--- a/src/Microsoft.Crank.AzureDevOpsWorker/JobPayloadParseException.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/JobPayloadParseException.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Crank.AzureDevOpsWorker
+{
+    internal sealed class JobPayloadParseException : Exception
+    {
+        public JobPayloadParseException(int payloadLength, Type parserExceptionType)
+            : base($"Job payload parsing failed ({payloadLength} bytes, {parserExceptionType.Name}).")
+        {
+        }
+    }
+}

--- a/src/Microsoft.Crank.AzureDevOpsWorker/PostProcessPayload.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/PostProcessPayload.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+
+namespace Microsoft.Crank.AzureDevOpsWorker
+{
+    public sealed class PostProcessPayload
+    {
+        private const int MaximumDisplayNameLength = 128;
+
+        public string Name { get; set; }
+
+        public string[] Args { get; set; } = Array.Empty<string>();
+
+        internal string GetSafeDisplayName()
+        {
+            var sanitizedName = new string((Name ?? String.Empty)
+                .Take(MaximumDisplayNameLength)
+                .Select(character =>
+                    Char.IsLetterOrDigit(character) ||
+                    character == ' ' ||
+                    character == '-' ||
+                    character == '_' ||
+                    character == '.' ||
+                    character == '(' ||
+                    character == ')'
+                        ? character
+                        : '_')
+                .ToArray())
+                .Trim();
+
+            return String.IsNullOrEmpty(sanitizedName) ? "post-process" : sanitizedName;
+        }
+    }
+}

--- a/src/Microsoft.Crank.AzureDevOpsWorker/PostProcessPayload.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/PostProcessPayload.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Crank.AzureDevOpsWorker
 
         public string Name { get; set; }
 
+        public bool Enabled { get; set; } = true;
+
         public string[] Args { get; set; } = Array.Empty<string>();
 
         internal string GetSafeDisplayName()

--- a/src/Microsoft.Crank.AzureDevOpsWorker/PostProcessRunner.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/PostProcessRunner.cs
@@ -1,0 +1,290 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Crank.AzureDevOpsWorker
+{
+    internal enum PostProcessStatus
+    {
+        Succeeded,
+        Failed,
+        TimedOut,
+        Canceled
+    }
+
+    internal sealed class PostProcessResult
+    {
+        public PostProcessResult(PostProcessStatus status)
+        {
+            Status = status;
+        }
+
+        public PostProcessStatus Status { get; }
+
+        public bool Succeeded => Status == PostProcessStatus.Succeeded;
+
+        public bool Canceled => Status == PostProcessStatus.Canceled;
+    }
+
+    internal sealed class PostProcessRunner
+    {
+        private static readonly TimeSpan DefaultPollInterval = TimeSpan.FromSeconds(2);
+        private readonly TimeSpan _pollInterval;
+
+        public PostProcessRunner(TimeSpan? pollInterval = null)
+        {
+            _pollInterval = pollInterval ?? DefaultPollInterval;
+        }
+
+        public async Task<PostProcessResult> RunAsync(
+            string executablePath,
+            PostProcessPayload postProcess,
+            string workingDirectory,
+            TimeSpan timeout,
+            Func<IReadOnlyCollection<string>, Task> writeLogsAsync,
+            Func<CancellationToken, Task<bool>> isTaskCanceledAsync,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(postProcess);
+            ArgumentNullException.ThrowIfNull(writeLogsAsync);
+
+            var displayName = postProcess.GetSafeDisplayName();
+
+            if (String.IsNullOrWhiteSpace(executablePath))
+            {
+                await WriteLogAsync(
+                    writeLogsAsync,
+                    $"Post-process '{displayName}' was requested, but no post-process executable is configured.");
+
+                return new PostProcessResult(PostProcessStatus.Failed);
+            }
+
+            if (timeout <= TimeSpan.Zero)
+            {
+                await WriteLogAsync(
+                    writeLogsAsync,
+                    $"Post-process '{displayName}' cannot start because its worker timeout is invalid.");
+
+                return new PostProcessResult(PostProcessStatus.Failed);
+            }
+
+            if (cancellationToken.IsCancellationRequested ||
+                (isTaskCanceledAsync != null && await isTaskCanceledAsync(CancellationToken.None)))
+            {
+                await WriteLogAsync(writeLogsAsync, $"Post-process '{displayName}' was canceled before it started.");
+                return new PostProcessResult(PostProcessStatus.Canceled);
+            }
+
+            var pendingLogs = new ConcurrentQueue<string>();
+
+            using var process = new Process
+            {
+                StartInfo = CreateStartInfo(executablePath, postProcess.Args, workingDirectory)
+            };
+
+            process.OutputDataReceived += (_, eventArgs) =>
+            {
+                if (eventArgs.Data != null)
+                {
+                    pendingLogs.Enqueue(eventArgs.Data);
+                }
+            };
+
+            process.ErrorDataReceived += (_, eventArgs) =>
+            {
+                if (eventArgs.Data != null)
+                {
+                    pendingLogs.Enqueue(eventArgs.Data);
+                }
+            };
+
+            await WriteLogAsync(writeLogsAsync, $"Starting post-process '{displayName}'.");
+
+            try
+            {
+                if (!process.Start())
+                {
+                    await WriteLogAsync(writeLogsAsync, $"Post-process '{displayName}' failed to start.");
+                    return new PostProcessResult(PostProcessStatus.Failed);
+                }
+            }
+            catch (Exception exception)
+            {
+                await WriteLogAsync(
+                    writeLogsAsync,
+                    $"Post-process '{displayName}' failed to start ({exception.GetType().Name}).");
+
+                return new PostProcessResult(PostProcessStatus.Failed);
+            }
+
+            try
+            {
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+
+                var stopwatch = Stopwatch.StartNew();
+                var terminationStatus = default(PostProcessStatus?);
+
+                while (!process.HasExited)
+                {
+                    await FlushLogsAsync(pendingLogs, writeLogsAsync);
+
+                    if (cancellationToken.IsCancellationRequested ||
+                        (isTaskCanceledAsync != null && await isTaskCanceledAsync(CancellationToken.None)))
+                    {
+                        terminationStatus = PostProcessStatus.Canceled;
+                        break;
+                    }
+
+                    if (stopwatch.Elapsed >= timeout)
+                    {
+                        terminationStatus = PostProcessStatus.TimedOut;
+                        break;
+                    }
+
+                    try
+                    {
+                        await Task.Delay(_pollInterval, cancellationToken);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        terminationStatus = PostProcessStatus.Canceled;
+                        break;
+                    }
+                }
+
+                if (terminationStatus.HasValue)
+                {
+                    TerminateProcess(process);
+                }
+
+                await WaitForExitAsync(process);
+                await FlushLogsAsync(pendingLogs, writeLogsAsync);
+
+                if (terminationStatus == PostProcessStatus.Canceled)
+                {
+                    await WriteLogAsync(writeLogsAsync, $"Post-process '{displayName}' was canceled.");
+                    return new PostProcessResult(PostProcessStatus.Canceled);
+                }
+
+                if (terminationStatus == PostProcessStatus.TimedOut)
+                {
+                    await WriteLogAsync(writeLogsAsync, $"Post-process '{displayName}' timed out after {timeout}.");
+                    return new PostProcessResult(PostProcessStatus.TimedOut);
+                }
+
+                if (process.ExitCode != 0)
+                {
+                    await WriteLogAsync(
+                        writeLogsAsync,
+                        $"Post-process '{displayName}' failed with exit code {process.ExitCode}.");
+
+                    return new PostProcessResult(PostProcessStatus.Failed);
+                }
+
+                await WriteLogAsync(writeLogsAsync, $"Post-process '{displayName}' completed successfully.");
+                return new PostProcessResult(PostProcessStatus.Succeeded);
+            }
+            catch (Exception exception)
+            {
+                TerminateProcess(process);
+                await WaitForExitAsync(process);
+
+                try
+                {
+                    await WriteLogAsync(
+                        writeLogsAsync,
+                        $"Post-process '{displayName}' failed ({exception.GetType().Name}).");
+                }
+                catch
+                {
+                }
+
+                return new PostProcessResult(PostProcessStatus.Failed);
+            }
+        }
+
+        internal static ProcessStartInfo CreateStartInfo(
+            string executablePath,
+            IEnumerable<string> arguments,
+            string workingDirectory)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = executablePath,
+                WorkingDirectory = String.IsNullOrWhiteSpace(workingDirectory)
+                    ? Directory.GetCurrentDirectory()
+                    : workingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+
+            foreach (var argument in arguments ?? Enumerable.Empty<string>())
+            {
+                startInfo.ArgumentList.Add(argument ?? String.Empty);
+            }
+
+            return startInfo;
+        }
+
+        private static async Task FlushLogsAsync(
+            ConcurrentQueue<string> pendingLogs,
+            Func<IReadOnlyCollection<string>, Task> writeLogsAsync)
+        {
+            var logs = new List<string>();
+
+            while (pendingLogs.TryDequeue(out var log))
+            {
+                logs.Add(log);
+            }
+
+            if (logs.Count > 0)
+            {
+                await writeLogsAsync(logs);
+            }
+        }
+
+        private static Task WriteLogAsync(
+            Func<IReadOnlyCollection<string>, Task> writeLogsAsync,
+            string message)
+        {
+            return writeLogsAsync(new[] { message });
+        }
+
+        private static void TerminateProcess(Process process)
+        {
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        private static async Task WaitForExitAsync(Process process)
+        {
+            try
+            {
+                await process.WaitForExitAsync();
+                process.WaitForExit();
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/src/Microsoft.Crank.AzureDevOpsWorker/Program.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/Program.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
                     // Mark the message as completed
                     await args.CompleteMessageAsync(message);
                 }
-                else 
+                else
                 {
                     if (!String.IsNullOrWhiteSpace(jobPayload.Condition))
                     {
@@ -223,7 +223,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
                     var arguments = String.Join(' ', jobPayload.Args);
 
                     Console.WriteLine($"{LogNow} Invoking crank with arguments: {arguments}");
-                    
+
                     if (Verbose)
                     {
                         Console.WriteLine($"{LogNow} Invoking crank with timeout: {jobPayload.Timeout}");
@@ -299,9 +299,9 @@ namespace Microsoft.Crank.AzureDevOpsWorker
 
                     // Mark the message as completed
                     await args.CompleteMessageAsync(message);
-                    
+
                     Console.WriteLine($"{LogNow} Job completed");
-                }                
+                }
             }
             catch (Exception e)
             {

--- a/src/Microsoft.Crank.AzureDevOpsWorker/Program.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/Program.cs
@@ -265,7 +265,8 @@ namespace Microsoft.Crank.AzureDevOpsWorker
                                             workerConfiguration.PostProcessTimeout,
                                             logs => ForwardPostProcessLogsAsync(devopsMessage, logs, taskLogBuilder),
                                             cancellationToken => IsTaskCompletedAsync(devopsMessage),
-                                            args.CancellationToken));
+                                            args.CancellationToken),
+                                        log => ForwardPostProcessLogsAsync(devopsMessage, new[] { log }, taskLogBuilder));
                                 },
                                 TryDeleteDirectory);
                         },

--- a/src/Microsoft.Crank.AzureDevOpsWorker/Program.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/Program.cs
@@ -6,7 +6,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 using Jint;
@@ -36,6 +38,14 @@ namespace Microsoft.Crank.AzureDevOpsWorker
             var certSniAuth = app.Option("--cert-sni", "Enable subject name / issuer based authentication (SNI).", CommandOptionType.NoValue);
             var managedIdentityClientId = app.Option("--mi-client-id", "Client ID of the user-assigned managed identity to use for authentication.", CommandOptionType.SingleValue);
             var verboseOption = app.Option("-v|--verbose", "Display verbose log.", CommandOptionType.NoValue);
+            var postProcessExecutableOption = app.Option(
+                "--post-process-executable <path>",
+                $"Trusted post-process executable path. Defaults to {WorkerConfiguration.PostProcessExecutableEnvironmentVariable}.",
+                CommandOptionType.SingleValue);
+            var postProcessTimeoutOption = app.Option(
+                "--post-process-timeout <timespan>",
+                $"Post-process timeout. Defaults to {WorkerConfiguration.PostProcessTimeoutEnvironmentVariable} or {WorkerConfiguration.DefaultPostProcessTimeout}.",
+                CommandOptionType.SingleValue);
 
             app.OnExecuteAsync(async cancellationToken =>
             {
@@ -48,6 +58,10 @@ namespace Microsoft.Crank.AzureDevOpsWorker
                 }
 
                 Verbose = verboseOption.HasValue();
+
+                var workerConfiguration = WorkerConfiguration.Create(
+                    postProcessExecutableOption.Value(),
+                    postProcessTimeoutOption.Value());
 
                 var queue = queueOption.Value();
 
@@ -75,13 +89,18 @@ namespace Microsoft.Crank.AzureDevOpsWorker
                     managedIdentityOptions = new ManagedIdentityOptions(managedIdentityClientId.Value());
                 }
 
-                await ProcessAzureQueue(connectionString, queue, certificateOptions, managedIdentityOptions);
+                await ProcessAzureQueue(connectionString, queue, certificateOptions, managedIdentityOptions, workerConfiguration);
             });
 
             return app.Execute(args);
         }
 
-        private static async Task ProcessAzureQueue(string connectionString, string queue, CertificateOptions certificateOptions, ManagedIdentityOptions managedIdentityOptions)
+        private static async Task ProcessAzureQueue(
+            string connectionString,
+            string queue,
+            CertificateOptions certificateOptions,
+            ManagedIdentityOptions managedIdentityOptions,
+            WorkerConfiguration workerConfiguration)
         {
             ServiceBusClient client;
 
@@ -114,7 +133,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
             });
 
             // Whenever a message is available on the queue
-            processor.ProcessMessageAsync += MessageHandler;
+            processor.ProcessMessageAsync += args => MessageHandler(args, workerConfiguration);
 
             processor.ProcessErrorAsync += ErrorHandler;
 
@@ -124,7 +143,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
             Console.ReadLine();
         }
 
-        private static async Task MessageHandler(ProcessMessageEventArgs args)
+        private static async Task MessageHandler(ProcessMessageEventArgs args, WorkerConfiguration workerConfiguration)
         {
             Console.WriteLine($"{LogNow} Processing message '{args.Message}'");
 
@@ -132,7 +151,6 @@ namespace Microsoft.Crank.AzureDevOpsWorker
 
             JobPayload jobPayload;
             DevopsMessage devopsMessage = null;
-            Job driverJob = null;
 
             try
             {
@@ -211,87 +229,51 @@ namespace Microsoft.Crank.AzureDevOpsWorker
                         Console.WriteLine($"{LogNow} Invoking crank with timeout: {jobPayload.Timeout}");
                     }
 
-                    var retries = 0;
+                    var taskLogBuilder = new StringBuilder();
+                    var postProcessRunner = new PostProcessRunner(TaskLogFeedDelay);
 
-                    do
-                    {
-                        if (retries > 0)
+                    var result = await AttemptExecution.RunWithRetriesAsync(
+                        jobPayload.Retries,
+                        async _ =>
                         {
-                            Console.WriteLine($"{LogNow} Job failed, attempt ({retries + 1} out of {jobPayload.Retries + 1}).");
-                        }
+                            taskLogBuilder.Clear();
 
-                        // Create a per-attempt temp working directory
-                        var workingDirectory = CreateTempWorkingDirectory();
-                        Console.WriteLine($"{LogNow} Created temp working directory: {workingDirectory}");
+                            var workingDirectory = CreateTempWorkingDirectory();
+                            Console.WriteLine($"{LogNow} Created temp working directory: {workingDirectory}");
 
-                        // Save the job payload files to disk (extracted step)
-                        MaterializeFiles(jobPayload, workingDirectory);
-
-                        // The DriverJob manages the application's lifetime and standard output
-                        driverJob = new Job("crank", arguments, workingDirectory);
-
-                        driverJob.OnStandardOutput = log => Console.WriteLine(log);
-
-                        driverJob.Start();
-
-                        // Pump application standard output while it's running
-                        while (driverJob.IsRunning)
-                        {
-                            var logs = driverJob.FlushStandardOutput().ToList();
-
-                            // Has the job run for too long?
-                            if ((DateTime.UtcNow - driverJob.StartTimeUtc) > jobPayload.Timeout)
-                            {
-                                var timeoutMessage = $"{LogNow} Job timed out ({jobPayload.Timeout}). The timeout can be increased in the payload message.";
-
-                                Console.WriteLine(timeoutMessage);
-                                logs.Add(timeoutMessage);
-
-                                driverJob.Stop();
-                            }
-
-                            // Send any page of logs to the AzDo task log feed
-                            if (logs.Any())
-                            {
-                                var success = await devopsMessage.SendTaskLogFeedsAsync(String.Join("\r\n", logs));
-
-                                if (!success)
+                            return await AttemptExecution.RunWithCleanupAsync(
+                                workingDirectory,
+                                async () =>
                                 {
-                                    Console.ForegroundColor = ConsoleColor.DarkYellow;
-                                    Console.WriteLine($"{LogNow} SendTaskLogFeedsAsync failed. If the task was canceled, this jobs should be stopped.");
-                                    Console.ResetColor();
-                                }
-                            }
+                                    MaterializeFiles(jobPayload, workingDirectory);
 
-                            // Check if task is still active (not canceled)
+                                    var crankResult = await RunCrankAsync(
+                                        jobPayload,
+                                        arguments,
+                                        workingDirectory,
+                                        devopsMessage,
+                                        taskLogBuilder,
+                                        args.CancellationToken);
 
-                            records = await devopsMessage.GetRecordsAsync();
-
-                            // This can return a stale value (see DevopsMessage.RecordsCacheTimeSpan)
-
-                            record = records.Value.FirstOrDefault(x => x.Id == devopsMessage.TaskInstanceId);
-
-                            if (record != null && record?.State == "completed")
-                            {
-                                Console.WriteLine($"{LogNow} Job is completed ({record.Result}), interrupting...");
-
-                                driverJob.Stop();
-                            }
-                            else
-                            {
-                                await Task.Delay(TaskLogFeedDelay);
-                            }
-                        }
-
-                        // Attempt-specific cleanup of the temp working directory
-                        TryDeleteDirectory(workingDirectory);
-
-                        retries++;
-                    }
-                    while (!driverJob.WasSuccessful && jobPayload.Retries >= retries);
+                                    return await AttemptExecution.ApplyPostProcessAsync(
+                                        crankResult,
+                                        jobPayload.PostProcess,
+                                        () => postProcessRunner.RunAsync(
+                                            workerConfiguration.PostProcessExecutablePath,
+                                            jobPayload.PostProcess,
+                                            workingDirectory,
+                                            workerConfiguration.PostProcessTimeout,
+                                            logs => ForwardPostProcessLogsAsync(devopsMessage, logs, taskLogBuilder),
+                                            cancellationToken => IsTaskCompletedAsync(devopsMessage),
+                                            args.CancellationToken));
+                                },
+                                TryDeleteDirectory);
+                        },
+                        attempt => Console.WriteLine(
+                            $"{LogNow} Job failed, attempt ({attempt + 1} out of {Math.Max(0, jobPayload.Retries) + 1})."));
 
                     // Mark the task as completed
-                    await devopsMessage.SendTaskCompletedEventAsync(driverJob.WasSuccessful ? DevopsMessage.ResultTypes.Succeeded : DevopsMessage.ResultTypes.Failed);
+                    await devopsMessage.SendTaskCompletedEventAsync(result.Succeeded ? DevopsMessage.ResultTypes.Succeeded : DevopsMessage.ResultTypes.Failed);
 
                     // Create a task log entry
                     var taskLogObjectString = await devopsMessage?.CreateTaskLogAsync();
@@ -308,7 +290,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
 
                         var taskLogId = taskLogObject["id"].ToString();
 
-                        await devopsMessage?.AppendToTaskLogAsync(taskLogId, driverJob.OutputBuilder.ToString());
+                        await devopsMessage?.AppendToTaskLogAsync(taskLogId, taskLogBuilder.ToString());
 
                         // Attach task log to the timeline record
                         await devopsMessage?.UpdateTaskTimelineRecordAsync(taskLogObjectString);
@@ -316,8 +298,6 @@ namespace Microsoft.Crank.AzureDevOpsWorker
 
                     // Mark the message as completed
                     await args.CompleteMessageAsync(message);
-
-                    driverJob.Stop();
                     
                     Console.WriteLine($"{LogNow} Job completed");
                 }                
@@ -347,17 +327,116 @@ namespace Microsoft.Crank.AzureDevOpsWorker
                     Console.WriteLine($"{LogNow} Failed to abandon the message: {f}");
                 }
             }
+        }
+
+        private static async Task<AttemptResult> RunCrankAsync(
+            JobPayload jobPayload,
+            string arguments,
+            string workingDirectory,
+            DevopsMessage devopsMessage,
+            StringBuilder taskLogBuilder,
+            CancellationToken cancellationToken)
+        {
+            var driverJob = new Job("crank", arguments, workingDirectory);
+            var canceled = false;
+
+            driverJob.OnStandardOutput = log => Console.WriteLine(log);
+
+            try
+            {
+                driverJob.Start();
+
+                while (driverJob.IsRunning)
+                {
+                    var logs = driverJob.FlushStandardOutput().ToList();
+
+                    if ((DateTime.UtcNow - driverJob.StartTimeUtc) > jobPayload.Timeout)
+                    {
+                        var timeoutMessage = $"{LogNow} Job timed out ({jobPayload.Timeout}). The timeout can be increased in the payload message.";
+
+                        Console.WriteLine(timeoutMessage);
+                        logs.Add(timeoutMessage);
+                        taskLogBuilder.AppendLine(timeoutMessage);
+                        driverJob.Stop();
+                    }
+
+                    await ForwardTaskLogsAsync(devopsMessage, logs);
+
+                    if (!driverJob.IsRunning)
+                    {
+                        break;
+                    }
+
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        canceled = true;
+                        Console.WriteLine($"{LogNow} Job cancellation requested, interrupting...");
+                        driverJob.Stop();
+                        break;
+                    }
+
+                    var records = await devopsMessage.GetRecordsAsync(forceRefresh: true);
+                    var record = records?.Value?.FirstOrDefault(x => x.Id == devopsMessage.TaskInstanceId);
+
+                    if (record?.State == "completed")
+                    {
+                        canceled = true;
+                        Console.WriteLine($"{LogNow} Job is completed ({record.Result}), interrupting...");
+                        driverJob.Stop();
+                    }
+                    else
+                    {
+                        await Task.Delay(TaskLogFeedDelay);
+                    }
+                }
+
+                return new AttemptResult(!canceled && driverJob.WasSuccessful, canceled);
+            }
             finally
             {
-                try
-                {
-                    driverJob?.Dispose();
-                }
-                catch (Exception e)
-                {
-                    Console.WriteLine($"{LogNow} Failed to dispose the job : {e}");
-                }
+                taskLogBuilder.Append(driverJob.OutputBuilder);
+                driverJob.Dispose();
             }
+        }
+
+        private static async Task ForwardPostProcessLogsAsync(
+            DevopsMessage devopsMessage,
+            IReadOnlyCollection<string> logs,
+            StringBuilder taskLogBuilder)
+        {
+            foreach (var log in logs)
+            {
+                Console.WriteLine(log);
+                taskLogBuilder.AppendLine(log);
+            }
+
+            await ForwardTaskLogsAsync(devopsMessage, logs);
+        }
+
+        private static async Task ForwardTaskLogsAsync(
+            DevopsMessage devopsMessage,
+            IReadOnlyCollection<string> logs)
+        {
+            if (logs == null || logs.Count == 0)
+            {
+                return;
+            }
+
+            var success = await devopsMessage.SendTaskLogFeedsAsync(String.Join("\r\n", logs));
+
+            if (!success)
+            {
+                Console.ForegroundColor = ConsoleColor.DarkYellow;
+                Console.WriteLine($"{LogNow} SendTaskLogFeedsAsync failed. If the task was canceled, this job should be stopped.");
+                Console.ResetColor();
+            }
+        }
+
+        private static async Task<bool> IsTaskCompletedAsync(DevopsMessage devopsMessage)
+        {
+            var records = await devopsMessage.GetRecordsAsync(forceRefresh: true);
+            var record = records?.Value?.FirstOrDefault(x => x.Id == devopsMessage.TaskInstanceId);
+            return record?.State == "completed";
         }
 
         private static Task ErrorHandler(ProcessErrorEventArgs args)

--- a/src/Microsoft.Crank.AzureDevOpsWorker/Program.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/Program.cs
@@ -46,6 +46,10 @@ namespace Microsoft.Crank.AzureDevOpsWorker
                 "--post-process-timeout <timespan>",
                 $"Post-process timeout. Defaults to {WorkerConfiguration.PostProcessTimeoutEnvironmentVariable} or {WorkerConfiguration.DefaultPostProcessTimeout}.",
                 CommandOptionType.SingleValue);
+            var maxAutoLockRenewalDurationOption = app.Option(
+                "--max-lock-renewal-duration <timespan>",
+                $"Maximum Service Bus message lock renewal duration. Defaults to {WorkerConfiguration.MaxAutoLockRenewalDurationEnvironmentVariable} or {WorkerConfiguration.DefaultMaxAutoLockRenewalDuration}.",
+                CommandOptionType.SingleValue);
 
             app.OnExecuteAsync(async cancellationToken =>
             {
@@ -61,7 +65,8 @@ namespace Microsoft.Crank.AzureDevOpsWorker
 
                 var workerConfiguration = WorkerConfiguration.Create(
                     postProcessExecutableOption.Value(),
-                    postProcessTimeoutOption.Value());
+                    postProcessTimeoutOption.Value(),
+                    maxAutoLockRenewalDurationOption.Value());
 
                 var queue = queueOption.Value();
 
@@ -125,12 +130,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
                 client = new ServiceBusClient(connectionString);
             }
 
-            var processor = client.CreateProcessor(queue, new ServiceBusProcessorOptions
-            {
-                AutoCompleteMessages = false,
-                MaxConcurrentCalls = 1, // Process one message at a time
-                MaxAutoLockRenewalDuration = TimeSpan.FromHours(1) // Maintaining the lock for as much as a job should run 
-            });
+            var processor = client.CreateProcessor(queue, CreateProcessorOptions(workerConfiguration));
 
             // Whenever a message is available on the queue
             processor.ProcessMessageAsync += args => MessageHandler(args, workerConfiguration);
@@ -145,9 +145,8 @@ namespace Microsoft.Crank.AzureDevOpsWorker
 
         private static async Task MessageHandler(ProcessMessageEventArgs args, WorkerConfiguration workerConfiguration)
         {
-            Console.WriteLine($"{LogNow} Processing message '{args.Message}'");
-
             var message = args.Message;
+            Console.WriteLine($"{LogNow} Processing Service Bus message.");
 
             JobPayload jobPayload;
             DevopsMessage devopsMessage = null;
@@ -215,6 +214,22 @@ namespace Microsoft.Crank.AzureDevOpsWorker
                         {
                             Console.WriteLine($"{LogNow} Could not evaluate condition [{jobPayload.Condition}], ignoring ...");
                         }
+                    }
+
+                    if (!workerConfiguration.HasSufficientLockRenewalDuration(jobPayload, out var requiredLockRenewalDuration))
+                    {
+                        await devopsMessage.SendTaskStartedEventAsync();
+
+                        var lockRenewalFailure =
+                            $"{LogNow} Job requires up to {requiredLockRenewalDuration} of message lock renewal, " +
+                            $"but the worker is configured for {workerConfiguration.MaxAutoLockRenewalDuration}. " +
+                            "Increase --max-lock-renewal-duration; the job will not be started.";
+
+                        Console.WriteLine(lockRenewalFailure);
+                        await devopsMessage.SendTaskLogFeedsAsync(lockRenewalFailure);
+                        await devopsMessage.SendTaskCompletedEventAsync(DevopsMessage.ResultTypes.Failed);
+                        await args.CompleteMessageAsync(message);
+                        return;
                     }
 
                     // Inform AzDo that the job is started
@@ -305,7 +320,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
             }
             catch (Exception e)
             {
-                Console.WriteLine($"{LogNow} Job failed: {e}");
+                Console.WriteLine($"{LogNow} Job failed: {FormatExceptionForLog(e)}");
 
                 Console.WriteLine("Stopping the task and releasing the message...");
 
@@ -328,6 +343,30 @@ namespace Microsoft.Crank.AzureDevOpsWorker
                     Console.WriteLine($"{LogNow} Failed to abandon the message: {f}");
                 }
             }
+        }
+
+        internal static ServiceBusProcessorOptions CreateProcessorOptions(WorkerConfiguration workerConfiguration)
+        {
+            ArgumentNullException.ThrowIfNull(workerConfiguration);
+
+            return new ServiceBusProcessorOptions
+            {
+                AutoCompleteMessages = false,
+                MaxConcurrentCalls = 1,
+                MaxAutoLockRenewalDuration = workerConfiguration.MaxAutoLockRenewalDuration
+            };
+        }
+
+        internal static string FormatExceptionForLog(Exception exception)
+        {
+            ArgumentNullException.ThrowIfNull(exception);
+
+            if (exception is JobPayloadParseException)
+            {
+                return $"{exception.GetType().Name}: {exception.Message}";
+            }
+
+            return exception.ToString();
         }
 
         private static async Task<AttemptResult> RunCrankAsync(

--- a/src/Microsoft.Crank.AzureDevOpsWorker/README.md
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/README.md
@@ -41,13 +41,15 @@ as:
 
 ```text
 (retries + 1) * (job timeout + enabled post-process timeout)
+    + 5-minute per-message safety margin
 ```
 
 An absent or disabled post-process contributes no post-process timeout, and a
-negative retry count is treated as zero. If the configured lock renewal duration
-is less than the calculated duration, the worker fails and completes the task
-without starting Crank. This prevents message lock expiry from redelivering and
-duplicating a long-running job.
+negative retry count is treated as zero. The fixed safety margin covers worker
+startup, log forwarding, attempt cleanup, and message settlement. If the
+configured lock renewal duration is less than the calculated duration, the
+worker fails and completes the task without starting Crank. This prevents
+message lock expiry from redelivering and duplicating a long-running job.
 
 ### Payload contract
 

--- a/src/Microsoft.Crank.AzureDevOpsWorker/README.md
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/README.md
@@ -1,0 +1,61 @@
+# Azure DevOps worker
+
+`crank-azdo` consumes Crank jobs from an Azure Service Bus queue and reports their
+status and output to Azure DevOps.
+
+## External post-processing
+
+The worker can invoke one trusted, separately deployed executable after a
+successful Crank attempt. The executable runs before the attempt directory is
+deleted and uses that directory as its working directory, so files produced by
+Crank, such as `crank-results.json`, are available.
+
+Install the executable on each worker host or in the worker container. Configure
+an absolute path when practical:
+
+```text
+crank-azdo ... --post-process-executable C:\tools\result-exporter.exe
+```
+
+On Linux:
+
+```text
+crank-azdo ... --post-process-executable /opt/crank/result-exporter
+```
+
+The path can instead be supplied through
+`CRANK_AZDO_POST_PROCESS_EXECUTABLE`. The command-line option takes precedence.
+Use a dedicated executable rather than a shell or general-purpose runtime,
+because payload arguments are passed directly to this trusted executable.
+
+Post-processing has a worker-controlled timeout of 10 minutes by default. Set
+`--post-process-timeout <timespan>` or
+`CRANK_AZDO_POST_PROCESS_TIMEOUT` to a positive .NET `TimeSpan`, for example
+`00:20:00`. The command-line option takes precedence.
+
+### Payload contract
+
+Jobs that need the hook add an optional `postProcess` object:
+
+```json
+{
+  "name": "crank",
+  "args": ["--json", "crank-results.json"],
+  "postProcess": {
+    "name": "Result export",
+    "args": ["upload", "--crank-json", "crank-results.json"]
+  }
+}
+```
+
+`name` is used only as a sanitized display name. `args` is passed with
+`ProcessStartInfo.ArgumentList`; it never selects the executable. Payloads
+without `postProcess` retain their existing behavior. A payload that requests
+post-processing fails explicitly when no executable is configured.
+
+The worker forwards the executable's standard output and standard error to the
+Azure DevOps task log, but does not log its full argument list. The executable
+is responsible for avoiding secrets in its own output. A nonzero exit code,
+startup failure, timeout, or task cancellation fails the attempt. Ordinary
+failures and timeouts use the job's existing retry count; cancellation stops
+further attempts. Cleanup still runs after every attempt.

--- a/src/Microsoft.Crank.AzureDevOpsWorker/README.md
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/README.md
@@ -43,15 +43,20 @@ Jobs that need the hook add an optional `postProcess` object:
   "args": ["--json", "crank-results.json"],
   "postProcess": {
     "name": "Result export",
+    "enabled": true,
     "args": ["upload", "--crank-json", "crank-results.json"]
   }
 }
 ```
 
-`name` is used only as a sanitized display name. `args` is passed with
-`ProcessStartInfo.ArgumentList`; it never selects the executable. Payloads
-without `postProcess` retain their existing behavior. A payload that requests
-post-processing fails explicitly when no executable is configured.
+`name` is used only as a sanitized display name. `enabled` is optional and
+defaults to `true`. When it is `false`, the worker logs that the named hook is
+disabled and treats the post-process step as successful without requiring or
+starting an executable or evaluating its arguments and cancellation callback.
+When enabled, `args` is passed with `ProcessStartInfo.ArgumentList`; it never
+selects the executable. Payloads without `postProcess` retain their existing
+behavior. A payload that requests enabled post-processing fails explicitly when
+no executable is configured.
 
 The worker forwards the executable's standard output and standard error to the
 Azure DevOps task log, but does not log its full argument list. The executable

--- a/src/Microsoft.Crank.AzureDevOpsWorker/README.md
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/README.md
@@ -33,6 +33,22 @@ Post-processing has a worker-controlled timeout of 10 minutes by default. Set
 `CRANK_AZDO_POST_PROCESS_TIMEOUT` to a positive .NET `TimeSpan`, for example
 `00:20:00`. The command-line option takes precedence.
 
+The worker renews each Service Bus message lock for up to one day by default.
+Set `--max-lock-renewal-duration <timespan>` or
+`CRANK_AZDO_MAX_LOCK_RENEWAL_DURATION` to change this worker-controlled limit.
+For every payload, the worker calculates the maximum supported execution time
+as:
+
+```text
+(retries + 1) * (job timeout + enabled post-process timeout)
+```
+
+An absent or disabled post-process contributes no post-process timeout, and a
+negative retry count is treated as zero. If the configured lock renewal duration
+is less than the calculated duration, the worker fails and completes the task
+without starting Crank. This prevents message lock expiry from redelivering and
+duplicating a long-running job.
+
 ### Payload contract
 
 Jobs that need the hook add an optional `postProcess` object:

--- a/src/Microsoft.Crank.AzureDevOpsWorker/WorkerConfiguration.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/WorkerConfiguration.cs
@@ -11,21 +11,30 @@ namespace Microsoft.Crank.AzureDevOpsWorker
     {
         internal const string PostProcessExecutableEnvironmentVariable = "CRANK_AZDO_POST_PROCESS_EXECUTABLE";
         internal const string PostProcessTimeoutEnvironmentVariable = "CRANK_AZDO_POST_PROCESS_TIMEOUT";
+        internal const string MaxAutoLockRenewalDurationEnvironmentVariable = "CRANK_AZDO_MAX_LOCK_RENEWAL_DURATION";
         internal static readonly TimeSpan DefaultPostProcessTimeout = TimeSpan.FromMinutes(10);
+        internal static readonly TimeSpan DefaultMaxAutoLockRenewalDuration = TimeSpan.FromDays(1);
 
-        private WorkerConfiguration(string postProcessExecutablePath, TimeSpan postProcessTimeout)
+        private WorkerConfiguration(
+            string postProcessExecutablePath,
+            TimeSpan postProcessTimeout,
+            TimeSpan maxAutoLockRenewalDuration)
         {
             PostProcessExecutablePath = postProcessExecutablePath;
             PostProcessTimeout = postProcessTimeout;
+            MaxAutoLockRenewalDuration = maxAutoLockRenewalDuration;
         }
 
         public string PostProcessExecutablePath { get; }
 
         public TimeSpan PostProcessTimeout { get; }
 
+        public TimeSpan MaxAutoLockRenewalDuration { get; }
+
         internal static WorkerConfiguration Create(
             string postProcessExecutablePath,
             string postProcessTimeout,
+            string maxAutoLockRenewalDuration,
             Func<string, string> environmentVariableReader = null)
         {
             environmentVariableReader ??= Environment.GetEnvironmentVariable;
@@ -38,17 +47,48 @@ namespace Microsoft.Crank.AzureDevOpsWorker
                 postProcessTimeout,
                 environmentVariableReader(PostProcessTimeoutEnvironmentVariable));
 
-            var timeout = DefaultPostProcessTimeout;
+            var lockRenewalDurationValue = FirstNonEmpty(
+                maxAutoLockRenewalDuration,
+                environmentVariableReader(MaxAutoLockRenewalDurationEnvironmentVariable));
 
-            if (!String.IsNullOrEmpty(timeoutValue) &&
-                (!TimeSpan.TryParse(timeoutValue, CultureInfo.InvariantCulture, out timeout) || timeout <= TimeSpan.Zero))
+            var timeout = ParsePositiveTimeSpan(
+                timeoutValue,
+                DefaultPostProcessTimeout,
+                "The post-process timeout",
+                nameof(postProcessTimeout));
+
+            var lockRenewalDuration = ParsePositiveTimeSpan(
+                lockRenewalDurationValue,
+                DefaultMaxAutoLockRenewalDuration,
+                "The maximum lock renewal duration",
+                nameof(maxAutoLockRenewalDuration));
+
+            return new WorkerConfiguration(executablePath, timeout, lockRenewalDuration);
+        }
+
+        internal bool HasSufficientLockRenewalDuration(JobPayload jobPayload, out TimeSpan requiredDuration)
+        {
+            ArgumentNullException.ThrowIfNull(jobPayload);
+
+            var attempts = (long)Math.Max(0, jobPayload.Retries) + 1;
+            var jobTimeoutTicks = Math.Max(0, jobPayload.Timeout.Ticks);
+            var postProcessTimeoutTicks = jobPayload.PostProcess?.Enabled == true
+                ? PostProcessTimeout.Ticks
+                : 0;
+
+            try
             {
-                throw new ArgumentException(
-                    $"The post-process timeout must be a positive TimeSpan. Received '{timeoutValue}'.",
-                    nameof(postProcessTimeout));
+                var attemptDurationTicks = checked(jobTimeoutTicks + postProcessTimeoutTicks);
+                var requiredDurationTicks = checked(attemptDurationTicks * attempts);
+                requiredDuration = TimeSpan.FromTicks(requiredDurationTicks);
+            }
+            catch (OverflowException)
+            {
+                requiredDuration = TimeSpan.MaxValue;
+                return false;
             }
 
-            return new WorkerConfiguration(executablePath, timeout);
+            return MaxAutoLockRenewalDuration >= requiredDuration;
         }
 
         private static string FirstNonEmpty(string first, string second)
@@ -59,6 +99,28 @@ namespace Microsoft.Crank.AzureDevOpsWorker
             }
 
             return String.IsNullOrWhiteSpace(second) ? null : second.Trim();
+        }
+
+        private static TimeSpan ParsePositiveTimeSpan(
+            string value,
+            TimeSpan defaultValue,
+            string description,
+            string parameterName)
+        {
+            if (String.IsNullOrEmpty(value))
+            {
+                return defaultValue;
+            }
+
+            if (!TimeSpan.TryParse(value, CultureInfo.InvariantCulture, out var parsedValue) ||
+                parsedValue <= TimeSpan.Zero)
+            {
+                throw new ArgumentException(
+                    $"{description} must be a positive TimeSpan. Received '{value}'.",
+                    parameterName);
+            }
+
+            return parsedValue;
         }
     }
 }

--- a/src/Microsoft.Crank.AzureDevOpsWorker/WorkerConfiguration.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/WorkerConfiguration.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+
+namespace Microsoft.Crank.AzureDevOpsWorker
+{
+    internal sealed class WorkerConfiguration
+    {
+        internal const string PostProcessExecutableEnvironmentVariable = "CRANK_AZDO_POST_PROCESS_EXECUTABLE";
+        internal const string PostProcessTimeoutEnvironmentVariable = "CRANK_AZDO_POST_PROCESS_TIMEOUT";
+        internal static readonly TimeSpan DefaultPostProcessTimeout = TimeSpan.FromMinutes(10);
+
+        private WorkerConfiguration(string postProcessExecutablePath, TimeSpan postProcessTimeout)
+        {
+            PostProcessExecutablePath = postProcessExecutablePath;
+            PostProcessTimeout = postProcessTimeout;
+        }
+
+        public string PostProcessExecutablePath { get; }
+
+        public TimeSpan PostProcessTimeout { get; }
+
+        internal static WorkerConfiguration Create(
+            string postProcessExecutablePath,
+            string postProcessTimeout,
+            Func<string, string> environmentVariableReader = null)
+        {
+            environmentVariableReader ??= Environment.GetEnvironmentVariable;
+
+            var executablePath = FirstNonEmpty(
+                postProcessExecutablePath,
+                environmentVariableReader(PostProcessExecutableEnvironmentVariable));
+
+            var timeoutValue = FirstNonEmpty(
+                postProcessTimeout,
+                environmentVariableReader(PostProcessTimeoutEnvironmentVariable));
+
+            var timeout = DefaultPostProcessTimeout;
+
+            if (!String.IsNullOrEmpty(timeoutValue) &&
+                (!TimeSpan.TryParse(timeoutValue, CultureInfo.InvariantCulture, out timeout) || timeout <= TimeSpan.Zero))
+            {
+                throw new ArgumentException(
+                    $"The post-process timeout must be a positive TimeSpan. Received '{timeoutValue}'.",
+                    nameof(postProcessTimeout));
+            }
+
+            return new WorkerConfiguration(executablePath, timeout);
+        }
+
+        private static string FirstNonEmpty(string first, string second)
+        {
+            if (!String.IsNullOrWhiteSpace(first))
+            {
+                return first.Trim();
+            }
+
+            return String.IsNullOrWhiteSpace(second) ? null : second.Trim();
+        }
+    }
+}

--- a/src/Microsoft.Crank.AzureDevOpsWorker/WorkerConfiguration.cs
+++ b/src/Microsoft.Crank.AzureDevOpsWorker/WorkerConfiguration.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Crank.AzureDevOpsWorker
         internal const string MaxAutoLockRenewalDurationEnvironmentVariable = "CRANK_AZDO_MAX_LOCK_RENEWAL_DURATION";
         internal static readonly TimeSpan DefaultPostProcessTimeout = TimeSpan.FromMinutes(10);
         internal static readonly TimeSpan DefaultMaxAutoLockRenewalDuration = TimeSpan.FromDays(1);
+        internal static readonly TimeSpan MessageLockRenewalSafetyMargin = TimeSpan.FromMinutes(5);
 
         private WorkerConfiguration(
             string postProcessExecutablePath,
@@ -79,7 +80,9 @@ namespace Microsoft.Crank.AzureDevOpsWorker
             try
             {
                 var attemptDurationTicks = checked(jobTimeoutTicks + postProcessTimeoutTicks);
-                var requiredDurationTicks = checked(attemptDurationTicks * attempts);
+                var attemptsDurationTicks = checked(attemptDurationTicks * attempts);
+                var requiredDurationTicks = checked(
+                    attemptsDurationTicks + MessageLockRenewalSafetyMargin.Ticks);
                 requiredDuration = TimeSpan.FromTicks(requiredDurationTicks);
             }
             catch (OverflowException)

--- a/test/Microsoft.Crank.IntegrationTests/AzureWorkerPostProcessTests.cs
+++ b/test/Microsoft.Crank.IntegrationTests/AzureWorkerPostProcessTests.cs
@@ -66,12 +66,31 @@ namespace Microsoft.Crank.IntegrationTests
             var malformedPayload = Encoding.UTF8.GetBytes(
                 $$"""{"postProcess":{"args":["{{secret}}"]}""");
 
-            var exception = Assert.Throws<Exception>(() => JobPayload.Deserialize(malformedPayload));
+            var exception = Assert.Throws<JobPayloadParseException>(() => JobPayload.Deserialize(malformedPayload));
 
+            Assert.Null(exception.InnerException);
             Assert.DoesNotContain(secret, exception.ToString());
             Assert.DoesNotContain(
                 Convert.ToHexString(Encoding.UTF8.GetBytes(secret)),
                 exception.ToString());
+        }
+
+        [Fact]
+        public void InvalidTimeoutParseFailureAndProgramLogAreSanitized()
+        {
+            const string secret = "PASSWORD=super-secret-invalid-timeout";
+            var payload = Encoding.UTF8.GetBytes(
+                $$"""{"name":"crank","timeout":"{{secret}}","args":[]}""");
+
+            var exception = Assert.Throws<JobPayloadParseException>(() => JobPayload.Deserialize(payload));
+            var programLog = Program.FormatExceptionForLog(exception);
+
+            Assert.Null(exception.InnerException);
+            Assert.Equal(
+                $"JobPayloadParseException: Job payload parsing failed ({payload.Length} bytes, FormatException).",
+                programLog);
+            Assert.DoesNotContain(secret, exception.ToString());
+            Assert.DoesNotContain(secret, programLog);
         }
 
         [Fact]
@@ -80,28 +99,36 @@ namespace Microsoft.Crank.IntegrationTests
             var environment = new Dictionary<string, string>
             {
                 [WorkerConfiguration.PostProcessExecutableEnvironmentVariable] = "environment-exporter",
-                [WorkerConfiguration.PostProcessTimeoutEnvironmentVariable] = "00:00:45"
+                [WorkerConfiguration.PostProcessTimeoutEnvironmentVariable] = "00:00:45",
+                [WorkerConfiguration.MaxAutoLockRenewalDurationEnvironmentVariable] = "02:00:00"
             };
 
             var environmentConfiguration = WorkerConfiguration.Create(
+                null,
                 null,
                 null,
                 name => environment.GetValueOrDefault(name));
 
             Assert.Equal("environment-exporter", environmentConfiguration.PostProcessExecutablePath);
             Assert.Equal(TimeSpan.FromSeconds(45), environmentConfiguration.PostProcessTimeout);
+            Assert.Equal(TimeSpan.FromHours(2), environmentConfiguration.MaxAutoLockRenewalDuration);
 
             var cliConfiguration = WorkerConfiguration.Create(
                 "cli-exporter",
                 "00:00:15",
+                "03:00:00",
                 name => environment.GetValueOrDefault(name));
 
             Assert.Equal("cli-exporter", cliConfiguration.PostProcessExecutablePath);
             Assert.Equal(TimeSpan.FromSeconds(15), cliConfiguration.PostProcessTimeout);
+            Assert.Equal(TimeSpan.FromHours(3), cliConfiguration.MaxAutoLockRenewalDuration);
 
-            var defaultConfiguration = WorkerConfiguration.Create(null, null, _ => null);
+            var defaultConfiguration = WorkerConfiguration.Create(null, null, null, _ => null);
             Assert.Null(defaultConfiguration.PostProcessExecutablePath);
             Assert.Equal(WorkerConfiguration.DefaultPostProcessTimeout, defaultConfiguration.PostProcessTimeout);
+            Assert.Equal(
+                WorkerConfiguration.DefaultMaxAutoLockRenewalDuration,
+                defaultConfiguration.MaxAutoLockRenewalDuration);
         }
 
         [Theory]
@@ -110,7 +137,90 @@ namespace Microsoft.Crank.IntegrationTests
         [InlineData("-00:00:01")]
         public void WorkerConfigurationRejectsInvalidTimeout(string timeout)
         {
-            Assert.Throws<ArgumentException>(() => WorkerConfiguration.Create(null, timeout, _ => null));
+            Assert.Throws<ArgumentException>(() => WorkerConfiguration.Create(null, timeout, null, _ => null));
+        }
+
+        [Theory]
+        [InlineData("not-a-timespan")]
+        [InlineData("00:00:00")]
+        [InlineData("-00:00:01")]
+        public void WorkerConfigurationRejectsInvalidLockRenewalDuration(string duration)
+        {
+            Assert.Throws<ArgumentException>(() => WorkerConfiguration.Create(null, null, duration, _ => null));
+        }
+
+        [Fact]
+        public void LockRenewalDurationAccountsForRetriesAndPostProcessTimeout()
+        {
+            var exactConfiguration = WorkerConfiguration.Create(
+                null,
+                "00:05:00",
+                "01:15:00",
+                _ => null);
+            var insufficientConfiguration = WorkerConfiguration.Create(
+                null,
+                "00:05:00",
+                "01:14:59.9999999",
+                _ => null);
+            var payload = new JobPayload
+            {
+                Timeout = TimeSpan.FromMinutes(20),
+                Retries = 2,
+                PostProcess = new PostProcessPayload()
+            };
+
+            Assert.True(exactConfiguration.HasSufficientLockRenewalDuration(payload, out var requiredDuration));
+            Assert.Equal(TimeSpan.FromMinutes(75), requiredDuration);
+            Assert.False(insufficientConfiguration.HasSufficientLockRenewalDuration(payload, out requiredDuration));
+            Assert.Equal(TimeSpan.FromMinutes(75), requiredDuration);
+            Assert.Equal(
+                TimeSpan.FromMinutes(75),
+                Program.CreateProcessorOptions(exactConfiguration).MaxAutoLockRenewalDuration);
+        }
+
+        [Fact]
+        public void LockRenewalDurationPreservesJobsWithoutEnabledPostProcess()
+        {
+            var configuration = WorkerConfiguration.Create(
+                null,
+                "00:10:00",
+                "00:30:00",
+                _ => null);
+            var payload = new JobPayload
+            {
+                Timeout = TimeSpan.FromMinutes(10),
+                Retries = 2
+            };
+
+            Assert.True(configuration.HasSufficientLockRenewalDuration(payload, out var requiredDuration));
+            Assert.Equal(TimeSpan.FromMinutes(30), requiredDuration);
+
+            payload.PostProcess = new PostProcessPayload { Enabled = false };
+            Assert.True(configuration.HasSufficientLockRenewalDuration(payload, out requiredDuration));
+            Assert.Equal(TimeSpan.FromMinutes(30), requiredDuration);
+
+            payload.PostProcess.Enabled = true;
+            Assert.False(configuration.HasSufficientLockRenewalDuration(payload, out requiredDuration));
+            Assert.Equal(TimeSpan.FromMinutes(60), requiredDuration);
+
+            payload.PostProcess = null;
+            payload.Retries = -1;
+            Assert.True(configuration.HasSufficientLockRenewalDuration(payload, out requiredDuration));
+            Assert.Equal(TimeSpan.FromMinutes(10), requiredDuration);
+        }
+
+        [Fact]
+        public void LockRenewalDurationOverflowFailsSafely()
+        {
+            var configuration = WorkerConfiguration.Create(null, null, null, _ => null);
+            var payload = new JobPayload
+            {
+                Timeout = TimeSpan.MaxValue,
+                Retries = 1
+            };
+
+            Assert.False(configuration.HasSufficientLockRenewalDuration(payload, out var requiredDuration));
+            Assert.Equal(TimeSpan.MaxValue, requiredDuration);
         }
 
         [Fact]

--- a/test/Microsoft.Crank.IntegrationTests/AzureWorkerPostProcessTests.cs
+++ b/test/Microsoft.Crank.IntegrationTests/AzureWorkerPostProcessTests.cs
@@ -1,0 +1,509 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Crank.AzureDevOpsWorker;
+using Xunit;
+
+namespace Microsoft.Crank.IntegrationTests
+{
+    public class AzureWorkerPostProcessTests
+    {
+        [Fact]
+        public void PayloadDeserializationSupportsOptionalPostProcess()
+        {
+            var payload = JobPayload.Deserialize(Encoding.UTF8.GetBytes(
+                """
+                {
+                  "name": "crank",
+                  "args": ["--json", "crank-results.json"],
+                  "postProcess": {
+                    "name": "Result export",
+                    "args": ["upload", "--crank-json", "crank-results.json"],
+                    "executable": "message-controlled.exe"
+                  }
+                }
+                """));
+
+            Assert.Equal("Result export", payload.PostProcess.Name);
+            Assert.Equal(new[] { "upload", "--crank-json", "crank-results.json" }, payload.PostProcess.Args);
+            Assert.Null(typeof(PostProcessPayload).GetProperty("Executable"));
+
+            var compatiblePayload = JobPayload.Deserialize(Encoding.UTF8.GetBytes(
+                """{"name":"crank","args":["--json","crank-results.json"]}"""));
+
+            Assert.Null(compatiblePayload.PostProcess);
+        }
+
+        [Fact]
+        public void PayloadParseFailureDoesNotExposeArguments()
+        {
+            const string secret = "super-secret-post-process-token";
+            var malformedPayload = Encoding.UTF8.GetBytes(
+                $$"""{"postProcess":{"args":["{{secret}}"]}""");
+
+            var exception = Assert.Throws<Exception>(() => JobPayload.Deserialize(malformedPayload));
+
+            Assert.DoesNotContain(secret, exception.ToString());
+            Assert.DoesNotContain(
+                Convert.ToHexString(Encoding.UTF8.GetBytes(secret)),
+                exception.ToString());
+        }
+
+        [Fact]
+        public void WorkerConfigurationUsesCliThenEnvironmentFallback()
+        {
+            var environment = new Dictionary<string, string>
+            {
+                [WorkerConfiguration.PostProcessExecutableEnvironmentVariable] = "environment-exporter",
+                [WorkerConfiguration.PostProcessTimeoutEnvironmentVariable] = "00:00:45"
+            };
+
+            var environmentConfiguration = WorkerConfiguration.Create(
+                null,
+                null,
+                name => environment.GetValueOrDefault(name));
+
+            Assert.Equal("environment-exporter", environmentConfiguration.PostProcessExecutablePath);
+            Assert.Equal(TimeSpan.FromSeconds(45), environmentConfiguration.PostProcessTimeout);
+
+            var cliConfiguration = WorkerConfiguration.Create(
+                "cli-exporter",
+                "00:00:15",
+                name => environment.GetValueOrDefault(name));
+
+            Assert.Equal("cli-exporter", cliConfiguration.PostProcessExecutablePath);
+            Assert.Equal(TimeSpan.FromSeconds(15), cliConfiguration.PostProcessTimeout);
+
+            var defaultConfiguration = WorkerConfiguration.Create(null, null, _ => null);
+            Assert.Null(defaultConfiguration.PostProcessExecutablePath);
+            Assert.Equal(WorkerConfiguration.DefaultPostProcessTimeout, defaultConfiguration.PostProcessTimeout);
+        }
+
+        [Theory]
+        [InlineData("not-a-timespan")]
+        [InlineData("00:00:00")]
+        [InlineData("-00:00:01")]
+        public void WorkerConfigurationRejectsInvalidTimeout(string timeout)
+        {
+            Assert.Throws<ArgumentException>(() => WorkerConfiguration.Create(null, timeout, _ => null));
+        }
+
+        [Fact]
+        public void ProcessStartInfoPreservesArgumentsAndTrustedExecutable()
+        {
+            var arguments = new[]
+            {
+                "upload",
+                "--label",
+                "value with spaces",
+                "\"quoted value\"",
+                "semi;colon",
+                String.Empty,
+                null
+            };
+
+            var startInfo = PostProcessRunner.CreateStartInfo(
+                "trusted-exporter",
+                arguments,
+                "trusted-working-directory");
+
+            Assert.Equal("trusted-exporter", startInfo.FileName);
+            Assert.Equal("trusted-working-directory", startInfo.WorkingDirectory);
+            Assert.Equal(
+                arguments.Select(argument => argument ?? String.Empty).ToArray(),
+                startInfo.ArgumentList.ToArray());
+            Assert.True(startInfo.RedirectStandardOutput);
+            Assert.True(startInfo.RedirectStandardError);
+            Assert.False(startInfo.UseShellExecute);
+        }
+
+        [Fact]
+        public async Task NoHookAndCrankFailureDoNotRunPostProcess()
+        {
+            var invocations = 0;
+
+            var noHookResult = await AttemptExecution.ApplyPostProcessAsync(
+                new AttemptResult(succeeded: true),
+                postProcess: null,
+                () =>
+                {
+                    invocations++;
+                    return Task.FromResult(new PostProcessResult(PostProcessStatus.Succeeded));
+                });
+
+            var failedCrankResult = await AttemptExecution.ApplyPostProcessAsync(
+                new AttemptResult(succeeded: false),
+                new PostProcessPayload(),
+                () =>
+                {
+                    invocations++;
+                    return Task.FromResult(new PostProcessResult(PostProcessStatus.Succeeded));
+                });
+
+            Assert.True(noHookResult.Succeeded);
+            Assert.False(failedCrankResult.Succeeded);
+            Assert.Equal(0, invocations);
+        }
+
+        [Fact]
+        public async Task MissingExecutableFailsExplicitlyWithoutLoggingArguments()
+        {
+            var logs = new List<string>();
+            var workingDirectory = CreateTestDirectory();
+            var payload = new PostProcessPayload
+            {
+                Name = "Export\r\n##vso[injected]",
+                Args = new[] { "--token", "super-secret" }
+            };
+
+            try
+            {
+                var result = await new PostProcessRunner(TimeSpan.FromMilliseconds(20)).RunAsync(
+                    executablePath: null,
+                    payload,
+                    workingDirectory,
+                    TimeSpan.FromSeconds(1),
+                    messages =>
+                    {
+                        logs.AddRange(messages);
+                        return Task.CompletedTask;
+                    },
+                    _ => Task.FromResult(false),
+                    CancellationToken.None);
+
+                var combinedLogs = String.Concat(logs);
+
+                Assert.Equal(PostProcessStatus.Failed, result.Status);
+                Assert.Contains("no post-process executable is configured", combinedLogs);
+                Assert.DoesNotContain("super-secret", combinedLogs);
+                Assert.DoesNotContain("##vso", combinedLogs);
+                Assert.DoesNotContain("\r", combinedLogs);
+                Assert.DoesNotContain("\n", combinedLogs);
+            }
+            finally
+            {
+                TryDelete(workingDirectory);
+            }
+        }
+
+        [Fact]
+        public async Task SuccessfulPostProcessUsesAttemptDirectoryAndRunsBeforeCleanup()
+        {
+            var workingDirectory = CreateTestDirectory();
+            var rawResultsPath = Path.Combine(workingDirectory, "crank-results.json");
+            File.WriteAllText(rawResultsPath, "{}");
+
+            var command = CreateSuccessCommand();
+            var logs = new List<string>();
+            var lifecycle = new List<string>();
+
+            var result = await AttemptExecution.RunWithCleanupAsync(
+                workingDirectory,
+                async () =>
+                {
+                    lifecycle.Add("post-process");
+
+                    var postProcessResult = await new PostProcessRunner(TimeSpan.FromMilliseconds(20)).RunAsync(
+                        command.Executable,
+                        new PostProcessPayload
+                        {
+                            Name = "Result export",
+                            Args = command.Arguments
+                        },
+                        workingDirectory,
+                        TimeSpan.FromSeconds(10),
+                        messages =>
+                        {
+                            logs.AddRange(messages);
+                            return Task.CompletedTask;
+                        },
+                        _ => Task.FromResult(false),
+                        CancellationToken.None);
+
+                    Assert.True(File.Exists(rawResultsPath));
+                    Assert.True(File.Exists(Path.Combine(workingDirectory, "post-working-directory.txt")));
+
+                    lifecycle.Add("post-process-complete");
+                    return new AttemptResult(postProcessResult.Succeeded, postProcessResult.Canceled);
+                },
+                directory =>
+                {
+                    lifecycle.Add("cleanup");
+                    Assert.True(File.Exists(rawResultsPath));
+                    Directory.Delete(directory, recursive: true);
+                });
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(new[] { "post-process", "post-process-complete", "cleanup" }, lifecycle);
+            Assert.Contains("post stdout", logs);
+            Assert.Contains("post stderr", logs);
+
+            var reportedWorkingDirectory = logs.Single(log => log.StartsWith("working-directory=", StringComparison.Ordinal))
+                .Substring("working-directory=".Length);
+
+            Assert.Equal(
+                Path.TrimEndingDirectorySeparator(Path.GetFullPath(workingDirectory)),
+                Path.TrimEndingDirectorySeparator(Path.GetFullPath(reportedWorkingDirectory)));
+            Assert.False(Directory.Exists(workingDirectory));
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task PostProcessFailureParticipatesInRetryState(bool timedOut)
+        {
+            var attempts = new List<int>();
+            var retries = new List<int>();
+            var firstAttemptStatus = timedOut ? PostProcessStatus.TimedOut : PostProcessStatus.Failed;
+
+            var result = await AttemptExecution.RunWithRetriesAsync(
+                retryCount: 2,
+                async attempt =>
+                {
+                    attempts.Add(attempt);
+
+                    return await AttemptExecution.ApplyPostProcessAsync(
+                        new AttemptResult(succeeded: true),
+                        new PostProcessPayload(),
+                        () => Task.FromResult(new PostProcessResult(
+                            attempt == 0 ? firstAttemptStatus : PostProcessStatus.Succeeded)));
+                },
+                retry => retries.Add(retry));
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(new[] { 0, 1 }, attempts);
+            Assert.Equal(new[] { 1 }, retries);
+        }
+
+        [Fact]
+        public async Task CanceledPostProcessDoesNotRetry()
+        {
+            var attempts = 0;
+
+            var result = await AttemptExecution.RunWithRetriesAsync(
+                retryCount: 2,
+                _ =>
+                {
+                    attempts++;
+                    return Task.FromResult(new AttemptResult(succeeded: false, canceled: true));
+                },
+                onRetry: null);
+
+            Assert.True(result.Canceled);
+            Assert.Equal(1, attempts);
+        }
+
+        [Fact]
+        public async Task FailedAttemptStillRunsCleanup()
+        {
+            var workingDirectory = CreateTestDirectory();
+            var cleanupCalled = false;
+
+            var result = await AttemptExecution.RunWithCleanupAsync(
+                workingDirectory,
+                () => Task.FromResult(new AttemptResult(succeeded: false)),
+                directory =>
+                {
+                    cleanupCalled = true;
+                    Directory.Delete(directory, recursive: true);
+                });
+
+            Assert.False(result.Succeeded);
+            Assert.True(cleanupCalled);
+            Assert.False(Directory.Exists(workingDirectory));
+        }
+
+        [Fact]
+        public async Task PostProcessTimeoutStopsTheProcess()
+        {
+            var workingDirectory = CreateTestDirectory();
+            var command = CreateSleepCommand();
+            var logs = new List<string>();
+            var stopwatch = Stopwatch.StartNew();
+
+            try
+            {
+                var result = await new PostProcessRunner(TimeSpan.FromMilliseconds(20)).RunAsync(
+                    command.Executable,
+                    new PostProcessPayload { Name = "Timeout test", Args = command.Arguments },
+                    workingDirectory,
+                    TimeSpan.FromMilliseconds(100),
+                    messages =>
+                    {
+                        logs.AddRange(messages);
+                        return Task.CompletedTask;
+                    },
+                    _ => Task.FromResult(false),
+                    CancellationToken.None);
+
+                Assert.Equal(PostProcessStatus.TimedOut, result.Status);
+                Assert.Contains(logs, log => log.Contains("timed out", StringComparison.Ordinal));
+                Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(10));
+            }
+            finally
+            {
+                TryDelete(workingDirectory);
+            }
+        }
+
+        [Fact]
+        public async Task AzureTaskCancellationStopsThePostProcess()
+        {
+            var workingDirectory = CreateTestDirectory();
+            var command = CreateSleepCommand();
+            var cancellationChecks = 0;
+            var stopwatch = Stopwatch.StartNew();
+
+            try
+            {
+                var result = await new PostProcessRunner(TimeSpan.FromMilliseconds(20)).RunAsync(
+                    command.Executable,
+                    new PostProcessPayload { Name = "Cancellation test", Args = command.Arguments },
+                    workingDirectory,
+                    TimeSpan.FromSeconds(30),
+                    _ => Task.CompletedTask,
+                    _ => Task.FromResult(++cancellationChecks >= 2),
+                    CancellationToken.None);
+
+                Assert.Equal(PostProcessStatus.Canceled, result.Status);
+                Assert.True(cancellationChecks >= 2);
+                Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(10));
+            }
+            finally
+            {
+                TryDelete(workingDirectory);
+            }
+        }
+
+        [Fact]
+        public async Task StartupFailureIsSanitized()
+        {
+            var workingDirectory = CreateTestDirectory();
+            var logs = new List<string>();
+
+            try
+            {
+                var result = await new PostProcessRunner(TimeSpan.FromMilliseconds(20)).RunAsync(
+                    Path.Combine(workingDirectory, "missing-exporter"),
+                    new PostProcessPayload
+                    {
+                        Name = "Result export",
+                        Args = new[] { "--token", "super-secret" }
+                    },
+                    workingDirectory,
+                    TimeSpan.FromSeconds(1),
+                    messages =>
+                    {
+                        logs.AddRange(messages);
+                        return Task.CompletedTask;
+                    },
+                    _ => Task.FromResult(false),
+                    CancellationToken.None);
+
+                var combinedLogs = String.Join(Environment.NewLine, logs);
+
+                Assert.Equal(PostProcessStatus.Failed, result.Status);
+                Assert.Contains("failed to start", combinedLogs);
+                Assert.DoesNotContain("super-secret", combinedLogs);
+                Assert.DoesNotContain("--token", combinedLogs);
+            }
+            finally
+            {
+                TryDelete(workingDirectory);
+            }
+        }
+
+        private static (string Executable, string[] Arguments) CreateSuccessCommand()
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                return (
+                    GetWindowsPowerShellPath(),
+                    new[]
+                    {
+                        "-NoLogo",
+                        "-NoProfile",
+                        "-NonInteractive",
+                        "-Command",
+                        "[IO.File]::WriteAllText('post-working-directory.txt', [Environment]::CurrentDirectory); " +
+                        "[Console]::Out.WriteLine('post stdout'); " +
+                        "[Console]::Error.WriteLine('post stderr'); " +
+                        "[Console]::Out.WriteLine('working-directory=' + [Environment]::CurrentDirectory)"
+                    });
+            }
+
+            return (
+                "/bin/sh",
+                new[]
+                {
+                    "-c",
+                    "pwd > post-working-directory.txt; " +
+                    "printf 'post stdout\\n'; " +
+                    "printf 'post stderr\\n' >&2; " +
+                    "printf 'working-directory=%s\\n' \"$PWD\""
+                });
+        }
+
+        private static (string Executable, string[] Arguments) CreateSleepCommand()
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                return (
+                    GetWindowsPowerShellPath(),
+                    new[]
+                    {
+                        "-NoLogo",
+                        "-NoProfile",
+                        "-NonInteractive",
+                        "-Command",
+                        "Start-Sleep -Seconds 30"
+                    });
+            }
+
+            return ("/bin/sh", new[] { "-c", "sleep 30" });
+        }
+
+        private static string GetWindowsPowerShellPath()
+        {
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.System),
+                "WindowsPowerShell",
+                "v1.0",
+                "powershell.exe");
+        }
+
+        private static string CreateTestDirectory()
+        {
+            var directory = Path.Combine(
+                AppContext.BaseDirectory,
+                "azure-worker-post-process-tests",
+                Guid.NewGuid().ToString("N"));
+
+            Directory.CreateDirectory(directory);
+            return directory;
+        }
+
+        private static void TryDelete(string directory)
+        {
+            try
+            {
+                if (Directory.Exists(directory))
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Microsoft.Crank.IntegrationTests/AzureWorkerPostProcessTests.cs
+++ b/test/Microsoft.Crank.IntegrationTests/AzureWorkerPostProcessTests.cs
@@ -152,15 +152,20 @@ namespace Microsoft.Crank.IntegrationTests
         [Fact]
         public void LockRenewalDurationAccountsForRetriesAndPostProcessTimeout()
         {
-            var exactConfiguration = WorkerConfiguration.Create(
+            var summedTimeoutConfiguration = WorkerConfiguration.Create(
                 null,
                 "00:05:00",
                 "01:15:00",
                 _ => null);
-            var insufficientConfiguration = WorkerConfiguration.Create(
+            var boundaryConfiguration = WorkerConfiguration.Create(
                 null,
                 "00:05:00",
-                "01:14:59.9999999",
+                "01:20:00",
+                _ => null);
+            var belowBoundaryConfiguration = WorkerConfiguration.Create(
+                null,
+                "00:05:00",
+                "01:19:59.9999999",
                 _ => null);
             var payload = new JobPayload
             {
@@ -169,13 +174,16 @@ namespace Microsoft.Crank.IntegrationTests
                 PostProcess = new PostProcessPayload()
             };
 
-            Assert.True(exactConfiguration.HasSufficientLockRenewalDuration(payload, out var requiredDuration));
-            Assert.Equal(TimeSpan.FromMinutes(75), requiredDuration);
-            Assert.False(insufficientConfiguration.HasSufficientLockRenewalDuration(payload, out requiredDuration));
-            Assert.Equal(TimeSpan.FromMinutes(75), requiredDuration);
+            Assert.Equal(TimeSpan.FromMinutes(5), WorkerConfiguration.MessageLockRenewalSafetyMargin);
+            Assert.False(summedTimeoutConfiguration.HasSufficientLockRenewalDuration(payload, out var requiredDuration));
+            Assert.Equal(TimeSpan.FromMinutes(80), requiredDuration);
+            Assert.True(boundaryConfiguration.HasSufficientLockRenewalDuration(payload, out requiredDuration));
+            Assert.Equal(TimeSpan.FromMinutes(80), requiredDuration);
+            Assert.False(belowBoundaryConfiguration.HasSufficientLockRenewalDuration(payload, out requiredDuration));
+            Assert.Equal(TimeSpan.FromMinutes(80), requiredDuration);
             Assert.Equal(
-                TimeSpan.FromMinutes(75),
-                Program.CreateProcessorOptions(exactConfiguration).MaxAutoLockRenewalDuration);
+                TimeSpan.FromMinutes(80),
+                Program.CreateProcessorOptions(boundaryConfiguration).MaxAutoLockRenewalDuration);
         }
 
         [Fact]
@@ -184,7 +192,7 @@ namespace Microsoft.Crank.IntegrationTests
             var configuration = WorkerConfiguration.Create(
                 null,
                 "00:10:00",
-                "00:30:00",
+                "00:35:00",
                 _ => null);
             var payload = new JobPayload
             {
@@ -193,20 +201,20 @@ namespace Microsoft.Crank.IntegrationTests
             };
 
             Assert.True(configuration.HasSufficientLockRenewalDuration(payload, out var requiredDuration));
-            Assert.Equal(TimeSpan.FromMinutes(30), requiredDuration);
+            Assert.Equal(TimeSpan.FromMinutes(35), requiredDuration);
 
             payload.PostProcess = new PostProcessPayload { Enabled = false };
             Assert.True(configuration.HasSufficientLockRenewalDuration(payload, out requiredDuration));
-            Assert.Equal(TimeSpan.FromMinutes(30), requiredDuration);
+            Assert.Equal(TimeSpan.FromMinutes(35), requiredDuration);
 
             payload.PostProcess.Enabled = true;
             Assert.False(configuration.HasSufficientLockRenewalDuration(payload, out requiredDuration));
-            Assert.Equal(TimeSpan.FromMinutes(60), requiredDuration);
+            Assert.Equal(TimeSpan.FromMinutes(65), requiredDuration);
 
             payload.PostProcess = null;
             payload.Retries = -1;
             Assert.True(configuration.HasSufficientLockRenewalDuration(payload, out requiredDuration));
-            Assert.Equal(TimeSpan.FromMinutes(10), requiredDuration);
+            Assert.Equal(TimeSpan.FromMinutes(15), requiredDuration);
         }
 
         [Fact]
@@ -215,8 +223,11 @@ namespace Microsoft.Crank.IntegrationTests
             var configuration = WorkerConfiguration.Create(null, null, null, _ => null);
             var payload = new JobPayload
             {
-                Timeout = TimeSpan.MaxValue,
-                Retries = 1
+                Timeout = TimeSpan.FromTicks(
+                    TimeSpan.MaxValue.Ticks -
+                    WorkerConfiguration.MessageLockRenewalSafetyMargin.Ticks +
+                    1),
+                Retries = 0
             };
 
             Assert.False(configuration.HasSufficientLockRenewalDuration(payload, out var requiredDuration));

--- a/test/Microsoft.Crank.IntegrationTests/AzureWorkerPostProcessTests.cs
+++ b/test/Microsoft.Crank.IntegrationTests/AzureWorkerPostProcessTests.cs
@@ -34,8 +34,24 @@ namespace Microsoft.Crank.IntegrationTests
                 """));
 
             Assert.Equal("Result export", payload.PostProcess.Name);
+            Assert.True(payload.PostProcess.Enabled);
             Assert.Equal(new[] { "upload", "--crank-json", "crank-results.json" }, payload.PostProcess.Args);
             Assert.Null(typeof(PostProcessPayload).GetProperty("Executable"));
+
+            var disabledPayload = JobPayload.Deserialize(Encoding.UTF8.GetBytes(
+                """
+                {
+                  "name": "crank",
+                  "args": [],
+                  "postProcess": {
+                    "name": "Disabled export",
+                    "enabled": false,
+                    "args": []
+                  }
+                }
+                """));
+
+            Assert.False(disabledPayload.PostProcess.Enabled);
 
             var compatiblePayload = JobPayload.Deserialize(Encoding.UTF8.GetBytes(
                 """{"name":"crank","args":["--json","crank-results.json"]}"""));
@@ -152,6 +168,61 @@ namespace Microsoft.Crank.IntegrationTests
             Assert.True(noHookResult.Succeeded);
             Assert.False(failedCrankResult.Succeeded);
             Assert.Equal(0, invocations);
+        }
+
+        [Fact]
+        public async Task DisabledPostProcessSkipsExecutionAndCleansUpSuccessfully()
+        {
+            var workingDirectory = CreateTestDirectory();
+            var attempts = 0;
+            var processStarts = 0;
+            var postProcessNetworkCalls = 0;
+            var logs = new List<string>();
+            var lifecycle = new List<string>();
+
+            var result = await AttemptExecution.RunWithRetriesAsync(
+                retryCount: 2,
+                _ =>
+                {
+                    attempts++;
+
+                    return AttemptExecution.RunWithCleanupAsync(
+                        workingDirectory,
+                        () => AttemptExecution.ApplyPostProcessAsync(
+                            new AttemptResult(succeeded: true),
+                            new PostProcessPayload
+                            {
+                                Name = "Optional export",
+                                Enabled = false,
+                                Args = new[] { "--token", "unused-secret" }
+                            },
+                            () =>
+                            {
+                                processStarts++;
+                                postProcessNetworkCalls++;
+                                return Task.FromResult(new PostProcessResult(PostProcessStatus.Succeeded));
+                            },
+                            log =>
+                            {
+                                logs.Add(log);
+                                lifecycle.Add("disabled-log");
+                                return Task.CompletedTask;
+                            }),
+                        directory =>
+                        {
+                            lifecycle.Add("cleanup");
+                            Directory.Delete(directory, recursive: true);
+                        });
+                },
+                onRetry: null);
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(1, attempts);
+            Assert.Equal(0, processStarts);
+            Assert.Equal(0, postProcessNetworkCalls);
+            Assert.Equal(new[] { "Post-process 'Optional export' is disabled." }, logs);
+            Assert.Equal(new[] { "disabled-log", "cleanup" }, lifecycle);
+            Assert.False(Directory.Exists(workingDirectory));
         }
 
         [Fact]

--- a/test/Microsoft.Crank.IntegrationTests/AzureWorkerTests.cs
+++ b/test/Microsoft.Crank.IntegrationTests/AzureWorkerTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Crank.IntegrationTests
         {
             var bytes = Convert.FromHexString(hexPayload);
 
-            Assert.Throws<Exception>(() => JobPayload.Deserialize(bytes));
+            Assert.Throws<JobPayloadParseException>(() => JobPayload.Deserialize(bytes));
         }
 
         [Theory]


### PR DESCRIPTION
## Summary

- reuse existing controller-side `afterJob` commands instead of adding a separate AzureDevOpsWorker post-process payload and runner
- expose the completed execution `result` to command conditions, allowing export only for successful, non-skipped scenarios while retaining cleanup commands after failures
- terminate the controller process tree on cancellation, including scripts/exporters; stop retrying canceled attempts
- keep the worker responsible for ordinary attempt logs, cleanup, timeout, retries, and message-lock renewal, not exporter execution

## Validation

- 21 targeted controller-command and worker tests, including success/failure/skip selection, cleanup, failing command exit codes, and real child-process termination
- Release build and local controller/worker NuGet packing
- changed worker and test files pass formatting checks; pre-existing controller whitespace remains unchanged

## Safety

No PerfLab conversion or Storage publishing implementation is added to Crank. Benchmarks owns the shared export profile and external converter. Publication remains disabled in every current Trend caller. Export runs on the controller host using the already-collected JSON and falls within the attempt timeout.