### PR TITLE
Collect traces before process dumps

### DIFF
--- a/src/Microsoft.Crank.Controller/JobConnection.cs
+++ b/src/Microsoft.Crank.Controller/JobConnection.cs
@@ -39,7 +39,10 @@ namespace Microsoft.Crank.Controller
         private int _uploadBufferSize = 1024 * 1024; // default is 80K which is too small on slow network connections
         private DateTime? _runningUtc;
         private string _jobName;
-        private bool _traceCollected;
+        private bool _traceDownloaded;
+        private bool _traceFinalized;
+        private readonly object _traceFinalizationLock = new object();
+        private Task _traceFinalizationTask;
 
         private int _outputCursor;
         private int _buildCursor;
@@ -651,6 +654,7 @@ namespace Microsoft.Crank.Controller
                         if (Job.Timeout > 0 && _runningUtc != null && DateTime.UtcNow - _runningUtc > TimeSpan.FromSeconds(Job.Timeout))
                         {
                             Log.Write($"'{_jobName}' has timed out, stopping...");
+                            await FinalizeTraceBeforeDumpAsync(collectDump: true);
                             await StopAsync(collectDump: true);
                         }
 
@@ -714,14 +718,40 @@ namespace Microsoft.Crank.Controller
             _keepAlive = false;
         }
 
-        public async Task DownloadTraceAsync()
+        public async Task FinalizeTraceBeforeDumpAsync(bool collectDump = false)
         {
-            if (!Job.DotNetTrace && !Job.Collect && !Job.Profile)
+            if (!Job.DumpProcess && !collectDump)
             {
                 return;
             }
 
-            // We can only download the trace for a job that has been stopped
+            if (!Job.DotNetTrace && !Job.Collect && !Job.Profile ||
+                await GetStateAsync() != JobState.Running)
+            {
+                return;
+            }
+
+            // Finalize the trace while the target process is still alive. The
+            // trace is downloaded after shutdown so the dump is captured as
+            // soon as possible against the same address space.
+            try
+            {
+                await GetTraceFinalizationTask();
+            }
+            catch (Exception e)
+            {
+                Log.WriteWarning($"Error while finalizing trace for '{Job.Service}'");
+                Log.Verbose(e.Message);
+            }
+        }
+
+        public async Task DownloadTraceAsync()
+        {
+            if (_traceDownloaded || !Job.DotNetTrace && !Job.Collect && !Job.Profile)
+            {
+                return;
+            }
+
             if (await GetStateAsync() != JobState.Stopped)
             {
                 return;
@@ -764,7 +794,7 @@ namespace Microsoft.Crank.Controller
                     traceDestination = traceDestination + "." + DateTime.Now.ToString("MM-dd-HH-mm-ss") + traceExtension;
                 }
 
-                await CollectTracesAsync();
+                await GetTraceFinalizationTask();
 
                 Log.Write($"Downloading trace file {traceDestination} ...");
 
@@ -777,7 +807,6 @@ namespace Microsoft.Crank.Controller
                     if (Job.ProfileType == Job.UltraProfileType)
                     {
                         Log.Write($"The file can be visualized with in https://profiler.firefox.com/");
-
                     }
                 }
                 catch (Exception e)
@@ -789,8 +818,7 @@ namespace Microsoft.Crank.Controller
                     StopKeepAlive();
                 }
 
-
-                _traceCollected = true;
+                _traceDownloaded = true;
             }
             catch (Exception e)
             {
@@ -799,9 +827,37 @@ namespace Microsoft.Crank.Controller
             }
         }
 
+        private Task GetTraceFinalizationTask()
+        {
+            lock (_traceFinalizationLock)
+            {
+                if (_traceFinalized)
+                {
+                    return Task.CompletedTask;
+                }
+
+                return _traceFinalizationTask ??= FinalizeTraceAsync();
+            }
+        }
+
+        private async Task FinalizeTraceAsync()
+        {
+            try
+            {
+                await CollectTracesAsync();
+            }
+            finally
+            {
+                lock (_traceFinalizationLock)
+                {
+                    _traceFinalizationTask = null;
+                }
+            }
+        }
+
         private async Task CollectTracesAsync()
         {
-            if (_traceCollected)
+            if (_traceFinalized)
             {
                 return;
             }
@@ -830,7 +886,7 @@ namespace Microsoft.Crank.Controller
 
             Console.WriteLine();
 
-            _traceCollected = true;
+            _traceFinalized = true;
         }
 
         public async Task DownloadDumpAsync()

--- a/src/Microsoft.Crank.Controller/Program.cs
+++ b/src/Microsoft.Crank.Controller/Program.cs
@@ -896,7 +896,13 @@ namespace Microsoft.Crank.Controller
 
                                                                 if (!service.WaitForExit)
                                                                 {
+                                                                    await Task.WhenAll(jobs.Select(job => job.FinalizeTraceBeforeDumpAsync()));
+
                                                                     await Task.WhenAll(jobs.Select(job => job.StopAsync()));
+
+                                                                    await Task.WhenAll(jobs.Select(job => job.DownloadDumpAsync()));
+
+                                                                    await Task.WhenAll(jobs.Select(job => job.DownloadTraceAsync()));
 
                                                                     await Task.WhenAll(jobs.Select(job => job.DeleteAsync()));
                                                                 }
@@ -955,6 +961,8 @@ namespace Microsoft.Crank.Controller
 
                                         await Task.Delay(1000);
                                     }
+
+                                    await Task.WhenAll(jobs.Select(job => job.FinalizeTraceBeforeDumpAsync()));
 
                                     // Stop a blocking job
                                     await Task.WhenAll(jobs.Select(job => job.StopAsync()));
@@ -1040,6 +1048,8 @@ namespace Microsoft.Crank.Controller
                         // Unless the jobs can't be stopped
                         if (!SpanShouldKeepJobRunning(jobName) || IsLastIteration())
                         {
+                            await Task.WhenAll(jobs.Select(job => job.FinalizeTraceBeforeDumpAsync()));
+
                             await Task.WhenAll(jobs.Select(job => job.StopAsync()));
                         }
 
@@ -1434,6 +1444,8 @@ namespace Microsoft.Crank.Controller
                 await Task.Delay(1000);
             }
 
+            await job.FinalizeTraceBeforeDumpAsync();
+
             await job.StopAsync();
 
             await job.TryUpdateJobAsync();
@@ -1694,6 +1706,8 @@ namespace Microsoft.Crank.Controller
                     break;
                 }
             }
+
+            await job.FinalizeTraceBeforeDumpAsync();
 
             await job.StopAsync();
 

--- a/test/Microsoft.Crank.IntegrationTests/CollectLinuxFactAttribute.cs
+++ b/test/Microsoft.Crank.IntegrationTests/CollectLinuxFactAttribute.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Microsoft.Crank.IntegrationTests
+{
+    class CollectLinuxFactAttribute : FactAttribute
+    {
+        public CollectLinuxFactAttribute()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                Skip = "Test requires Linux";
+            }
+            else if (GetEffectiveUserId() != 0)
+            {
+                Skip = "Test requires root for perf_event_open";
+            }
+            else if (Environment.OSVersion.Version < new Version(6, 4))
+            {
+                Skip = "Test requires Linux kernel 6.4 or later";
+            }
+            else if (!HasPerfCapability())
+            {
+                Skip = "Test requires CAP_PERFMON or CAP_SYS_ADMIN";
+            }
+        }
+
+        [DllImport("libc")]
+        private static extern uint geteuid();
+
+        private static uint GetEffectiveUserId() => geteuid();
+
+        private static bool HasPerfCapability()
+        {
+            const int CapSysAdmin = 21;
+            const int CapPerfmon = 38;
+
+            foreach (string line in File.ReadLines("/proc/self/status"))
+            {
+                if (!line.StartsWith("CapEff:", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                ulong capabilities = ulong.Parse(line.AsSpan("CapEff:".Length), NumberStyles.HexNumber);
+                return (capabilities & (1UL << CapSysAdmin)) != 0 ||
+                    (capabilities & (1UL << CapPerfmon)) != 0;
+            }
+
+            return false;
+        }
+    }
+}

--- a/test/Microsoft.Crank.IntegrationTests/CommonTests.cs
+++ b/test/Microsoft.Crank.IntegrationTests/CommonTests.cs
@@ -269,6 +269,46 @@ namespace Microsoft.Crank.IntegrationTests
             Assert.Contains("(100%)", result.StandardOutput);
         }
 
+        [CollectLinuxFact]
+        public async Task CollectLinuxTraceAndDump()
+        {
+            var outputDirectory = Path.Combine(_crankTestsDirectory, "trace-and-dump");
+            Directory.CreateDirectory(outputDirectory);
+
+            var tracePath = Path.Combine(outputDirectory, "application.nettrace");
+            var dumpPath = Path.Combine(outputDirectory, "application.dmp");
+
+            File.Delete(tracePath);
+            File.Delete(dumpPath);
+
+            var result = await ProcessUtil.RunAsync(
+                "dotnet",
+                $"exec {Path.Combine(_crankDirectory, "crank.dll")} --config ./assets/hello.benchmarks.yml --scenario hello --profile local " +
+                "--application.framework net10.0 --application.sdkVersion 10.0.400 --application.runtimeVersion 10.0.11 --application.aspNetCoreVersion 10.0.11 " +
+                "--application.dotnetTrace true --application.dotnetTraceCollectMode collect-linux " +
+                $"--application.options.traceOutput {tracePath} --application.options.dumpType mini --application.options.dumpOutput {dumpPath}",
+                workingDirectory: _crankTestsDirectory,
+                captureOutput: true,
+                timeout: DefaultTimeOut,
+                throwOnError: false,
+                outputDataReceived: t => { _output.WriteLine($"[CTL] {t}"); }
+            );
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.True(new FileInfo(tracePath).Length > 0);
+            Assert.True(new FileInfo(dumpPath).Length > 0);
+
+            var traceIndex = result.StandardOutput.IndexOf("Server is collecting trace file", StringComparison.Ordinal);
+            var stopIndex = result.StandardOutput.IndexOf("Stopping job 'application'", StringComparison.Ordinal);
+            var dumpIndex = result.StandardOutput.IndexOf("Downloading dump file", StringComparison.Ordinal);
+            var traceDownloadIndex = result.StandardOutput.IndexOf("Downloading trace file", StringComparison.Ordinal);
+
+            Assert.True(traceIndex >= 0);
+            Assert.True(stopIndex > traceIndex);
+            Assert.True(dumpIndex > stopIndex);
+            Assert.True(traceDownloadIndex > dumpIndex);
+        }
+
         [Fact]
         public async Task Iterations()
         {


### PR DESCRIPTION
Finalize active traces before stopping jobs that also request dumps, avoiding profiler interference with dump capture. Add Linux functional coverage for collecting a perf-based trace and dump from the same process.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>